### PR TITLE
Change serverlist request URL and Protocol

### DIFF
--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -58,7 +58,7 @@ void Parse(std::string Data,SOCKET CSocket){
             NetReset();
             Terminate = true;
             TCPTerminate = true;
-            Data = Code + HTTP::Post("https://backend.beammp.com/servers","");
+            Data = Code + HTTP::Get("https://backend.beammp.com/servers-info");
             break;
         case 'C':
             ListOfMods.clear();


### PR DESCRIPTION
This changes the serverlist request from:

POST https://backend.beammp.com/servers

to:

GET https://backend.beammp.com/servers-info

This is done in order to allow for more caching on the backend side, which will alleviate the load on the database and backend applications, and improve performance and reliability for users. 