### PR TITLE
remove key if auth is unsuccessful

### DIFF
--- a/src/Security/Login.cpp
+++ b/src/Security/Login.cpp
@@ -94,7 +94,8 @@ void CheckLocalKey(){
             d.Parse(Buffer.c_str());
             if (Buffer == "-1" || Buffer.at(0) != '{' || d.HasParseError()) {
                 error(Buffer);
-                fatal("Invalid answer from authentication servers, please try again later!");
+                info("Invalid answer from authentication servers.");
+                UpdateKey(nullptr);
             }
             if(d["success"].GetBool()){
                 LoginAuth = true;


### PR DESCRIPTION
Changed so the key file gets removed if the launcher gets an invalid response from the backend (usually a JS error and some html)  instead of a JSON while authenticating with the key file.
This should probably be fixed on the backend side.