### PR TITLE
remove "game is newer than recommended"

### DIFF
--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -248,8 +248,6 @@ void PreGame(const std::string& GamePath){
     info("Game Version : " + GameVer);
     if(GameVer < CurrVer){
         fatal("Game version is old! Please update.");
-    }else if(GameVer > CurrVer){
-        warn("Game is newer than recommended, multiplayer may not work as intended!");
     }
     CheckMP(GetGamePath() + "mods/multiplayer");
 


### PR DESCRIPTION
It confuses people, and they'll know the game updated when the mod breaks anyways.
People can't read, so let's remove stuff they may not read correctly.