### PR TITLE
Emit a useful message if cleaning the mods folder fails

### DIFF
--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -205,7 +205,7 @@ void CheckMP(const std::string& Path) {
             }
         }
     } catch (...) {
-        fatal("Please close the game, and try again!");
+        fatal("We were unable to clean the multiplayer mods folder! Is the game still running or do you have something open in that folder?");
     }
 
 }


### PR DESCRIPTION
The launcher complains if it can not delete a file when it's trying to clean the mods folder out. However the message it emits is unhelpful and does not offer a suggestion to what is going on.

This commit addresses this issue by telling the user what the launcher is trying to do and suggests checking if something is currently open in that directory. I figure not having to go into detail in *where* the folder is not necessary and (primarily) only happens if the user is inspecting the folder themselves and already knows where the folder is.