### PR TITLE
Fix - Linux patch not needed on MacOS Wine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ cmake-build-release
 /*.sh
 /*.obj
 /*.exe
+/*.DS_store
+*.DS_store
+/build
+/.vscode


### PR DESCRIPTION
Related to #64

I've provided an option to select which version we are using and to save that choice. I don't believe this will be used in its current form in the final release, but it functions properly for now.

Update .gitignore file to don't puch any bad stuff.