### PR TITLE
Update Check for Game Files on Native Linux

### DIFF
--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -186,7 +186,7 @@ void LegitimacyCheck() {
     auto root = tyti::vdf::read(libraryFolders);
 
     for (auto folderInfo : root.childs) {
-        if (std::filesystem::exists(folderInfo.second->attribs["path"] + "/steamapps/common/BeamNG.drive/")) {
+        if (std::filesystem::exists(folderInfo.second->attribs["path"] + "/steamapps/common/BeamNG.drive/integrity.json")){
             GameDir = folderInfo.second->attribs["path"] + "/steamapps/common/BeamNG.drive/";
             break;
         }


### PR DESCRIPTION
Beforehand, the launcher would check only if the game directory existed. This would lead to an error if the game was moved through Steam since Steam leaves the BeamNG.Drive directory behind. Now it checks for to see if integrity.json is inside. I also removed some commented out code I seem to have left behind when I was porting it.

I agree to this code (and the whole port to native Linux since the #63 was locked and I couldn't agree there) being licensed under AGPL 3.