### PR TITLE
Fix UB which was causing the http proxy to crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
+add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
+
 file(GLOB source_files "src/*.cpp" "src/*/*.cpp" "src/*/*.hpp" "include/*.h"  "include/*/*.h" "include/*/*/*.h" "include/*.hpp"  "include/*/*.hpp" "include/*/*/*.hpp")
 find_package(httplib CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -5,7 +5,6 @@
 ///
 /// Created by Anonymous275 on 7/18/2020
 ///
-#define CPPHTTPLIB_OPENSSL_SUPPORT
 
 #include "Http.h"
 #include <Logger.h>


### PR DESCRIPTION
This fixes a stack corruption error which was triggered by the http proxy handling a request.