### PR TITLE
Add BeamMP patreon to the allowed links

### DIFF
--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -68,7 +68,7 @@ void StartSync(const std::string& Data) {
 }
 
 bool IsAllowedLink(const std::string& Link) {
-    std::regex link_pattern(R"(https:\/\/(?:\w+)?(?:\.)?(?:beammp\.com|discord\.gg))");
+    std::regex link_pattern(R"(https:\/\/(?:\w+)?(?:\.)?(?:beammp\.com|discord\.gg|patreon\.com\/BeamMP))");
     std::smatch link_match;
     return std::regex_search(Link, link_match, link_pattern) && link_match.position() == 0;
 }


### PR DESCRIPTION
Adds the BeamMP patreon link to the list of urls that are allowed to be opened externally by the game