### PR TITLE
Add --skip-ssl-verify cli option

### DIFF
--- a/include/Http.h
+++ b/include/Http.h
@@ -17,4 +17,5 @@ public:
     static void StartProxy();
 public:
     static bool isDownload;
+    static inline bool SkipSslVerify = false;
 };

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -69,6 +69,10 @@ std::string HTTP::Get(const std::string& IP) {
     httplib::Client cli(IP.substr(0, pos).c_str());
     cli.set_connection_timeout(std::chrono::seconds(10));
     cli.set_follow_location(true);
+    if (SkipSslVerify) {
+        debug("Skipping SSL server validation via --skip-ssl-verify");
+        cli.enable_server_certificate_verification(false);
+    }
     auto res = cli.Get(IP.substr(pos).c_str(), ProgressBar);
     std::string Ret;
 
@@ -98,6 +102,10 @@ std::string HTTP::Post(const std::string& IP, const std::string& Fields) {
 
     httplib::Client cli(IP.substr(0, pos).c_str());
     cli.set_connection_timeout(std::chrono::seconds(10));
+    if (SkipSslVerify) {
+        debug("Skipping SSL server validation via --skip-ssl-verify");
+        cli.enable_server_certificate_verification(false);
+    }
     std::string Ret;
 
     if (!Fields.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,13 @@ int main(int argc, char* argv[]) {
 
     GetEP(argv[0]);
 
+    for (int i = 0; i < argc; ++i) {
+        if (std::string_view(argv[i]) == "--skip-ssl-verify") {
+            info("SSL verification skip enabled");
+            HTTP::SkipSslVerify = true;
+        }
+    }
+
     InitLauncher(argc, argv);
 
     try {


### PR DESCRIPTION
This is a temporary fix for if anyone has issues with SSL certificate validation. The use of this must come with the disclaimer that, obviously, this bypasses the security that SSL gives entirely. Anyone could MITM you at that point. Don't use, basically.