### PR TITLE
Fix GetGamePath

### DIFF
--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -8,6 +8,7 @@
 
 #if defined(_WIN32)
 #include <windows.h>
+#include <shlobj.h>
 #elif defined(__linux__)
 #include "vdf_parser.hpp"
 #include <pwd.h>
@@ -40,17 +41,17 @@ std::string GetGamePath() {
     Path = QueryKey(hKey, 4);
 
     if (Path.empty()) {
-        sk = R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders)";
-        openRes = RegOpenKeyEx(HKEY_CURRENT_USER, sk, 0, KEY_ALL_ACCESS, &hKey);
-        if (openRes != ERROR_SUCCESS) {
-            sk = R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders)";
-            openRes = RegOpenKeyEx(HKEY_CURRENT_USER, sk, 0, KEY_ALL_ACCESS, &hKey);
+        Path = "";
+        char appDataPath[MAX_PATH];
+        HRESULT result = SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath);
+        if (SUCCEEDED(result)) {
+            Path = appDataPath;
         }
-        if (openRes != ERROR_SUCCESS) {
+
+        if (Path.empty()) {
             fatal("Cannot get Local Appdata directory");
         }
 
-        Path = QueryKey(hKey, 5);
         Path += "\\BeamNG.drive\\";
     }
 


### PR DESCRIPTION
Previously, the registry was used to get the local appdata folder for the user folder. I've switched this over to a windows api function which fixes some cases where the launcher wouldn't be able to find the appdata folder in the registry.