### PR TITLE
Fix empty modlist

### DIFF
--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -514,6 +514,8 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
 void SyncResources(SOCKET Sock) {
     std::string Ret = Auth(Sock);
 
+    debug("Mod info: " + Ret);
+
     auto ModInfos = ModInfo::ParseModInfosFromPacket(Ret);
 
     if (!ModInfos.empty()) {


### PR DESCRIPTION
This PR fixes the launcher getting confused when the server sends an empty mod list using the new downloading system. 
Related server PR: