### PR TITLE
Speed up response times by waiting for http requests on another thread.

### DIFF
--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -114,7 +114,10 @@ void Parse(std::string Data, SOCKET CSocket) {
         NetReset();
         Terminate = true;
         TCPTerminate = true;
-        Data = Code + HTTP::Get("https://backend.beammp.com/servers-info");
+        Data.clear();
+        std::thread([&]() {
+            CoreSend(Code + HTTP::Get("https://backend.beammp.com/servers-info"));
+        }).detach();
         break;
     case 'C':
         StartSync(Data);
@@ -210,7 +213,10 @@ void Parse(std::string Data, SOCKET CSocket) {
             }
             Data = "N" + Auth.dump();
         } else {
-            Data = "N" + Login(Data.substr(Data.find(':') + 1));
+            Data.clear();
+            std::thread([&]() {
+                CoreSend(Code + Login(Data.substr(Data.find(':') + 1)));
+            }).detach();
         }
         break;
     case 'W':


### PR DESCRIPTION
If, for example, the client requests the serverlist multiple times and then tries to login the launcher will first wait for those requests to finish. Thereby putting the other core communication (such as login) on hold.