### PR TITLE
Fix port cli argument

### DIFF
--- a/include/Http.h
+++ b/include/Http.h
@@ -17,5 +17,4 @@ public:
     static void StartProxy();
 public:
     static bool isDownload;
-    static inline bool SkipSslVerify = false;
 };

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -232,7 +232,6 @@ void LinuxPatch() {
 
 void InitLauncher() {
     SetConsoleTitleA(("BeamMP Launcher v" + std::string(GetVer()) + GetPatch()).c_str());
-    InitLog();
     CheckName();
     LinuxPatch();
     CheckLocalKey();

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -235,7 +235,6 @@ void InitLauncher() {
     CheckName();
     LinuxPatch();
     CheckLocalKey();
-    ConfigInit();
     CheckForUpdates(std::string(GetVer()) + GetPatch());
 }
 #elif defined(__linux__)
@@ -244,7 +243,6 @@ void InitLauncher() {
     info("BeamMP Launcher v" + GetVer() + GetPatch());
     CheckName();
     CheckLocalKey();
-    ConfigInit();
     CheckForUpdates(std::string(GetVer()) + GetPatch());
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,21 +38,7 @@ int main(int argc, const char** argv) try {
 
     curl_global_init(CURL_GLOBAL_ALL);
 
-#if defined(_WIN32)
-    system("cls");
-#elif defined(__linux__)
-    system("clear");
-#endif
-
-
     GetEP(argv[0]);
-
-    for (int i = 0; i < argc; ++i) {
-        if (std::string_view(argv[i]) == "--skip-ssl-verify") {
-            info("SSL verification skip enabled");
-            HTTP::SkipSslVerify = true;
-        }
-    }
 
     InitLog();
     InitOptions(argc, argv, options);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ int main(int argc, const char** argv) try {
     GetEP(argv[0]);
 
     InitLog();
+    ConfigInit();
     InitOptions(argc, argv, options);
     InitLauncher();
 


### PR DESCRIPTION
Fixes --port and -p by proccessing the config file before the cli arguments, before it would first set --port because it was passed and then overwrite it with the value from the config. Also removed some useless code related to cli args.