### PR TITLE
Add missing vcpkg package for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Remember to change `C:/vcpkg` to wherever you have vcpkg installed.
 Make sure you have the necessary development tools installed
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf groupinstall "Development Tools"`
+- Fedora: `sudo dnf groupinstall "Development Tools" && sudo dnf install vcpkg`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 


### PR DESCRIPTION
```
BeamMP-Launcher on  master via △ v3.30.5 
 ❯ sudo dnf group info "Development Tools" 
Dernière vérification de l’expiration des métadonnées effectuée il y a 0:48:01 le mer. 11 déc. 2024 08:39:18.
Groupe : Outils de développement
 Description : Ces outils comprennent des outils de développement principaux comme git et cvs.
 Paquets obligatoires :
   gettext
 Paquets par défaut :
   diffstat
   doxygen
   git
   patch
   patchutils
   subversion
   systemtap
 Paquets optionnels :
   buildbot
   colordiff
   cvs
   cvs2cl
   cvsps
   darcs
   dejagnu
   expect
   gambas3-ide
   git-annex
   git-cola
   git2cl
   gitg
   gtranslator
   highlight
   lcov
   manedit
   meld
   monotone
   myrepos
   nemiver
   qgit
   quilt
   rapidsvn
   rcs
   robodoc
   scanmem
   subunit
   svn2cl
   tig
   tortoisehg
   translate-toolkit
   utrac
```
vcpkg isn't part of the Development Tools group on Fedora.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
