### PR TITLE
Build on linux without vcpkg

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -14,13 +14,8 @@ jobs:
         with:
             submodules: 'true'
       
-      - name: Restore artifacts, or run vcpkg, build and cache artifacts
-        uses: lukka/run-vcpkg@v7
-        id: runvcpkg
-        with:
-            vcpkgArguments: 'zlib nlohmann-json openssl cpp-httplib[openssl]'
-            vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-            vcpkgGitCommitId: '40616a5e954f7be1077ef37db3fbddbd5dcd1ca6'
+      - name: Install dependencies
+        run: sudo apt-get install -y build-essential libcpp-httplib-dev nlohmann-json3-dev libcurlpp-dev
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build-linux
@@ -28,7 +23,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{github.workspace}}/build-linux
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE='${{ runner.workspace }}/b/vcpkg/scripts/buildsystems/vcpkg.cmake'
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         working-directory: ${{github.workspace}}/build-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
 
 file(GLOB source_files "src/*.cpp" "src/*/*.cpp" "src/*/*.hpp" "include/*.h"  "include/*/*.h" "include/*/*/*.h" "include/*.hpp"  "include/*/*.hpp" "include/*/*/*.hpp")
-find_package(httplib CONFIG REQUIRED)
+
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(CURL REQUIRED)
 
@@ -23,15 +23,18 @@ add_executable(${PROJECT_NAME} ${source_files})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "BeamMP-Launcher")
 
 if (WIN32)
+    find_package(httplib CONFIG REQUIRED)
     find_package(ZLIB REQUIRED)
     find_package(OpenSSL REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE
             ZLIB::ZLIB OpenSSL::SSL OpenSSL::Crypto ws2_32 httplib::httplib nlohmann_json::nlohmann_json CURL::libcurl)
 elseif (UNIX)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(cpp-httplib REQUIRED cpp-httplib)
     find_package(ZLIB REQUIRED)
     find_package(OpenSSL REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE
-            ZLIB::ZLIB OpenSSL::SSL OpenSSL::Crypto CURL::libcurl)
+            ZLIB::ZLIB OpenSSL::SSL OpenSSL::Crypto CURL::libcurl cpp-httplib)
 else(WIN32) #MINGW
     add_definitions("-D_WIN32_WINNT=0x0600")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -s --static")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,5 @@ else(WIN32) #MINGW
     target_link_libraries(${PROJECT_NAME} ssl crypto ws2_32 ssp crypt32 z CURL::libcurl)
 endif(WIN32)
 target_include_directories(${PROJECT_NAME} PRIVATE "include")
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Remember to change `C:/vcpkg` to wherever you have vcpkg installed.
 
 Make sure you have `vcpkg` installed, as well as basic development tools, often found in packages, for example:
 
-- Debian: `sudo apt install build-essential`
+- Debian: `sudo apt install build-essential libcpp-httplib-dev nlohmann-json3-dev libcurlpp-dev`
 - Fedora: `sudo dnf groupinstall "Development Tools"`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
@@ -38,7 +38,7 @@ Make sure you have `vcpkg` installed, as well as basic development tools, often 
 ### Release
 
 In the root directory of the project,
-1. `cmake -DCMAKE_BUILD_TYPE=Release . -B bin -DCMAKE_TOOLCHAIN_FILE=~/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux`
+1. `cmake -DCMAKE_BUILD_TYPE=Release . -B bin -DCMAKE_INSTALL_PREFIX=~/.local`
 2. `cmake --build bin --parallel --config Release`
 
 ### Debug


### PR DESCRIPTION
At least on ubuntu this can easily be built without vcpkg.

Also it should use the prefix `~/.local` by default so it does not require root to install.
