### PR TITLE
Use a JSON body for HTTP Get requests instead of query params

### DIFF
--- a/include/Http.h
+++ b/include/Http.h
@@ -9,9 +9,9 @@
 #include <string>
 class HTTP {
 public:
-    static bool Download(const std::string& IP, const std::string& Path);
+    static bool Download(const std::string& IP, const std::string& Fields, const std::string& Path);
     static std::string Post(const std::string& IP, const std::string& Fields);
-    static std::string Get(const std::string& IP);
+    static std::string Get(const std::string& IP, const std::string& Fields = "");
     static bool ProgressBar(size_t c, size_t t);
     static void StartProxy();
 public:

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -164,9 +164,9 @@ void CheckName() {
 }
 
 void CheckForUpdates(const std::string& CV) {
-    std::string LatestHash = HTTP::Get("https://backend.beammp.com/sha/launcher?branch=" + Branch + "&pk=" + PublicKey);
-    std::string LatestVersion = HTTP::Get(
-        "https://backend.beammp.com/version/launcher?branch=" + Branch + "&pk=" + PublicKey);
+    std::string requestBody = R"({"branch": ")" + Branch + R"(","pk":")" + PublicKey + R"("})";
+    std::string LatestHash = HTTP::Get("https://backend.beammp.com/sha/launcher", requestBody);
+    std::string LatestVersion = HTTP::Get("https://backend.beammp.com/version/launcher", requestBody);
 
     transform(LatestHash.begin(), LatestHash.end(), LatestHash.begin(), ::tolower);
     std::string EP(GetEP() + GetEN()), Back(GetEP() + "BeamMP-Launcher.back");
@@ -182,11 +182,7 @@ void CheckForUpdates(const std::string& CV) {
             fs::remove(Back);
             fs::rename(EP, Back);
             info("Downloading Launcher update " + LatestHash);
-            HTTP::Download(
-                "https://backend.beammp.com/builds/launcher?download=true"
-                "&pk="
-                    + PublicKey + "&branch=" + Branch,
-                EP);
+            HTTP::Download("https://backend.beammp.com/builds/launcher?download=true", requestBody, EP);
             URelaunch();
 #endif
         } else {
@@ -307,7 +303,8 @@ void PreGame(const std::string& GamePath) {
     info("Game user path: " + GetGamePath());
 
     if (!options.no_download) {
-        std::string LatestHash = HTTP::Get("https://backend.beammp.com/sha/mod?branch=" + Branch + "&pk=" + PublicKey);
+        std::string requestBody = R"({"branch": ")" + Branch + R"(","pk":")" + PublicKey + R"("})";
+        std::string LatestHash = HTTP::Get("https://backend.beammp.com/sha/mod", requestBody);
         transform(LatestHash.begin(), LatestHash.end(), LatestHash.begin(), ::tolower);
         LatestHash.erase(std::remove_if(LatestHash.begin(), LatestHash.end(),
                              [](auto const& c) -> bool { return !std::isalnum(c); }),
@@ -332,10 +329,7 @@ void PreGame(const std::string& GamePath) {
 
         if (FileHash != LatestHash) {
             info("Downloading BeamMP Update " + LatestHash);
-            HTTP::Download("https://backend.beammp.com/builds/client?download=true"
-                           "&pk="
-                    + PublicKey + "&branch=" + Branch,
-                ZipPath);
+            HTTP::Download("https://backend.beammp.com/builds/client?download=true", requestBody, ZipPath);
         }
 
         std::string Target(GetGamePath() + "mods/unpacked/beammp");


### PR DESCRIPTION
Uses a json body for requests instead of query params. This prevents the launcher from logging the pk if the request fails.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
