### PR TITLE
Switch to wstring for paths on windows

### DIFF
--- a/include/Http.h
+++ b/include/Http.h
@@ -10,7 +10,7 @@
 #include <string>
 class HTTP {
 public:
-    static bool Download(const std::string& IP, const std::string& Path);
+    static bool Download(const std::string& IP, const std::wstring& Path);
     static std::string Post(const std::string& IP, const std::string& Fields);
     static std::string Get(const std::string& IP);
     static bool ProgressBar(size_t c, size_t t);

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -15,4 +15,11 @@ void debug(const std::string& toPrint);
 void error(const std::string& toPrint);
 void info(const std::string& toPrint);
 void warn(const std::string& toPrint);
+
+void except(const std::wstring& toPrint);
+void fatal(const std::wstring& toPrint);
+void debug(const std::wstring& toPrint);
+void error(const std::wstring& toPrint);
+void info(const std::wstring& toPrint);
+void warn(const std::wstring& toPrint);
 std::string getDate();

--- a/include/Security/Init.h
+++ b/include/Security/Init.h
@@ -7,9 +7,9 @@
 ///
 #pragma once
 #include <string>
-void PreGame(const std::string& GamePath);
-std::string CheckVer(const std::string& path);
-void InitGame(const std::string& Dir);
-std::string GetGameDir();
+void PreGame(const std::wstring& GamePath);
+std::string CheckVer(const std::wstring& path);
+void InitGame(const std::wstring& Dir);
+std::wstring GetGameDir();
 void LegitimacyCheck();
 void CheckLocalKey();

--- a/include/Startup.h
+++ b/include/Startup.h
@@ -11,9 +11,9 @@
 #include <vector>
 
 void InitLauncher();
-std::string GetEP(const char* P = nullptr);
-std::string GetGamePath();
+std::wstring GetEP(const wchar_t* P = nullptr);
+std::wstring GetGamePath();
 std::string GetVer();
 std::string GetPatch();
-std::string GetEN();
+std::wstring GetEN();
 void ConfigInit();

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -1,4 +1,9 @@
 #pragma once
+#include <filesystem>
+#include <fstream>
+#include <locale>
+#include <openssl/err.h>
+#include <openssl/evp.h>
 #include <string>
 #include <vector>
 
@@ -17,4 +22,132 @@ namespace Utils {
             Val.push_back(s);
         return Val;
     };
+    inline std::string ToString(const std::wstring& w) {
+        return std::wstring_convert<std::codecvt<wchar_t, char, std::mbstate_t>>().to_bytes(w);
+    }
+    inline std::wstring ToWString(const std::string& s) {
+        return std::wstring_convert<std::codecvt<wchar_t, char, std::mbstate_t>>().from_bytes(s);
+    }
+    inline std::string GetSha256HashReallyFast(const std::string& filename) {
+        try {
+            EVP_MD_CTX* mdctx;
+            const EVP_MD* md;
+            uint8_t sha256_value[EVP_MAX_MD_SIZE];
+            md = EVP_sha256();
+            if (md == nullptr) {
+                throw std::runtime_error("EVP_sha256() failed");
+            }
+
+            mdctx = EVP_MD_CTX_new();
+            if (mdctx == nullptr) {
+                throw std::runtime_error("EVP_MD_CTX_new() failed");
+            }
+            if (!EVP_DigestInit_ex2(mdctx, md, NULL)) {
+                EVP_MD_CTX_free(mdctx);
+                throw std::runtime_error("EVP_DigestInit_ex2() failed");
+            }
+
+            std::ifstream stream(filename, std::ios::binary);
+
+            const size_t FileSize = std::filesystem::file_size(filename);
+            size_t Read = 0;
+            std::vector<char> Data;
+            while (Read < FileSize) {
+                Data.resize(size_t(std::min<size_t>(FileSize - Read, 4096)));
+                size_t RealDataSize = Data.size();
+                stream.read(Data.data(), std::streamsize(Data.size()));
+                if (stream.eof() || stream.fail()) {
+                    RealDataSize = size_t(stream.gcount());
+                }
+                Data.resize(RealDataSize);
+                if (RealDataSize == 0) {
+                    break;
+                }
+                if (RealDataSize > 0 && !EVP_DigestUpdate(mdctx, Data.data(), Data.size())) {
+                    EVP_MD_CTX_free(mdctx);
+                    throw std::runtime_error("EVP_DigestUpdate() failed");
+                }
+                Read += RealDataSize;
+            }
+            unsigned int sha256_len = 0;
+            if (!EVP_DigestFinal_ex(mdctx, sha256_value, &sha256_len)) {
+                EVP_MD_CTX_free(mdctx);
+                throw std::runtime_error("EVP_DigestFinal_ex() failed");
+            }
+            EVP_MD_CTX_free(mdctx);
+
+            std::string result;
+            for (size_t i = 0; i < sha256_len; i++) {
+                char buf[3];
+                sprintf(buf, "%02x", sha256_value[i]);
+                buf[2] = 0;
+                result += buf;
+            }
+            return result;
+        } catch (const std::exception& e) {
+            error("Sha256 hashing of '" + filename + "' failed: " + e.what());
+            return "";
+        }
+    }
+    inline std::string GetSha256HashReallyFast(const std::wstring& filename) {
+        try {
+            EVP_MD_CTX* mdctx;
+            const EVP_MD* md;
+            uint8_t sha256_value[EVP_MAX_MD_SIZE];
+            md = EVP_sha256();
+            if (md == nullptr) {
+                throw std::runtime_error("EVP_sha256() failed");
+            }
+
+            mdctx = EVP_MD_CTX_new();
+            if (mdctx == nullptr) {
+                throw std::runtime_error("EVP_MD_CTX_new() failed");
+            }
+            if (!EVP_DigestInit_ex2(mdctx, md, NULL)) {
+                EVP_MD_CTX_free(mdctx);
+                throw std::runtime_error("EVP_DigestInit_ex2() failed");
+            }
+
+            std::wifstream stream(filename, std::ios::binary);
+
+            const size_t FileSize = std::filesystem::file_size(filename);
+            size_t Read = 0;
+            std::vector<wchar_t> Data;
+            while (Read < FileSize) {
+                Data.resize(size_t(std::min<size_t>(FileSize - Read, 4096)));
+                size_t RealDataSize = Data.size();
+                stream.read(Data.data(), std::streamsize(Data.size()));
+                if (stream.eof() || stream.fail()) {
+                    RealDataSize = size_t(stream.gcount());
+                }
+                Data.resize(RealDataSize);
+                if (RealDataSize == 0) {
+                    break;
+                }
+                if (RealDataSize > 0 && !EVP_DigestUpdate(mdctx, Data.data(), Data.size())) {
+                    EVP_MD_CTX_free(mdctx);
+                    throw std::runtime_error("EVP_DigestUpdate() failed");
+                }
+                Read += RealDataSize;
+            }
+            unsigned int sha256_len = 0;
+            if (!EVP_DigestFinal_ex(mdctx, sha256_value, &sha256_len)) {
+                EVP_MD_CTX_free(mdctx);
+                throw std::runtime_error("EVP_DigestFinal_ex() failed");
+            }
+            EVP_MD_CTX_free(mdctx);
+
+            std::string result;
+            for (size_t i = 0; i < sha256_len; i++) {
+                char buf[3];
+                sprintf(buf, "%02x", sha256_value[i]);
+                buf[2] = 0;
+                result += buf;
+            }
+            return result;
+        } catch (const std::exception& e) {
+            error(L"Sha256 hashing of '" + filename + L"' failed: " + ToWString(e.what()));
+            return "";
+        }
+    }
 };

--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -20,6 +20,7 @@
 
 #include "Logger.h"
 #include "Startup.h"
+#include "Utils.h"
 #include <Security/Init.h>
 #include <filesystem>
 #include <thread>
@@ -27,9 +28,9 @@
 
 unsigned long GamePID = 0;
 #if defined(_WIN32)
-std::string QueryKey(HKEY hKey, int ID);
-std::string GetGamePath() {
-    static std::string Path;
+std::wstring QueryKey(HKEY hKey, int ID);
+std::wstring GetGamePath() {
+    static std::wstring Path;
     if (!Path.empty())
         return Path;
 
@@ -42,23 +43,25 @@ std::string GetGamePath() {
     Path = QueryKey(hKey, 4);
 
     if (Path.empty()) {
-        Path = "";
-        char appDataPath[MAX_PATH];
-        HRESULT result = SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath);
+        Path = L"";
+        wchar_t* appDataPath = new wchar_t[MAX_PATH];
+        HRESULT result = SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath);
         if (SUCCEEDED(result)) {
             Path = appDataPath;
         }
+
+        delete[] appDataPath;
 
         if (Path.empty()) {
             fatal("Cannot get Local Appdata directory");
         }
 
-        Path += "\\BeamNG.drive\\";
+        Path += L"\\BeamNG.drive\\";
     }
 
     std::string Ver = CheckVer(GetGameDir());
     Ver = Ver.substr(0, Ver.find('.', Ver.find('.') + 1));
-    Path += Ver + "\\";
+    Path += Utils::ToWString(Ver) + L"\\";
     return Path;
 }
 #elif defined(__linux__)
@@ -76,22 +79,22 @@ std::string GetGamePath() {
 #endif
 
 #if defined(_WIN32)
-void StartGame(std::string Dir) {
+void StartGame(std::wstring Dir) {
     BOOL bSuccess = FALSE;
     PROCESS_INFORMATION pi;
-    STARTUPINFO si = { 0 };
+    STARTUPINFOW si = { 0 };
     si.cb = sizeof(si);
-    std::string BaseDir = Dir; //+"\\Bin64";
+    std::wstring BaseDir = Dir; //+"\\Bin64";
     // Dir += R"(\Bin64\BeamNG.drive.x64.exe)";
-    Dir += "\\BeamNG.drive.exe";
-    std::string gameArgs = "";
+    Dir += L"\\BeamNG.drive.exe";
+    std::wstring gameArgs = L"";
 
     for (int i = 0; i < options.game_arguments_length; i++) {
-        gameArgs += " ";
-        gameArgs += options.game_arguments[i];
+        gameArgs += L" ";
+        gameArgs += Utils::ToWString(options.game_arguments[i]);
     }
 
-    bSuccess = CreateProcessA(nullptr, (LPSTR)(Dir + gameArgs).c_str(), nullptr, nullptr, TRUE, 0, nullptr, BaseDir.c_str(), &si, &pi);
+    bSuccess = CreateProcessW(nullptr, (wchar_t*)(Dir + gameArgs).c_str(), nullptr, nullptr, TRUE, 0, nullptr, BaseDir.c_str(), &si, &pi);
     if (bSuccess) {
         info("Game Launched!");
         GamePID = pi.dwProcessId;
@@ -134,7 +137,7 @@ void StartGame(std::string Dir) {
 }
 #endif
 
-void InitGame(const std::string& Dir) {
+void InitGame(const std::wstring& Dir) {
     if (!options.no_launch) {
         std::thread Game(StartGame, Dir);
         Game.detach();

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -8,6 +8,7 @@
 
 #include "Logger.h"
 #include "Startup.h"
+#include "Utils.h"
 #include <chrono>
 #include <fstream>
 #include <sstream>
@@ -37,7 +38,7 @@ std::string getDate() {
 }
 void InitLog() {
     std::ofstream LFS;
-    LFS.open(GetEP() + "Launcher.log");
+    LFS.open(GetEP() + L"Launcher.log");
     if (!LFS.is_open()) {
         error("logger file init failed!");
     } else
@@ -45,7 +46,13 @@ void InitLog() {
 }
 void addToLog(const std::string& Line) {
     std::ofstream LFS;
-    LFS.open(GetEP() + "Launcher.log", std::ios_base::app);
+    LFS.open(GetEP() + L"Launcher.log", std::ios_base::app);
+    LFS << Line.c_str();
+    LFS.close();
+}
+void addToLog(const std::wstring& Line) {
+    std::wofstream LFS;
+    LFS.open(GetEP() + L"Launcher.log", std::ios_base::app);
     LFS << Line.c_str();
     LFS.close();
 }
@@ -81,5 +88,41 @@ void fatal(const std::string& toPrint) {
 void except(const std::string& toPrint) {
     std::string Print = getDate() + "[EXCEP] " + toPrint + "\n";
     std::cout << Print;
+    addToLog(Print);
+}
+
+
+void info(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[INFO] " + toPrint + L"\n";
+    std::wcout << Print;
+    addToLog(Print);
+}
+void debug(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[DEBUG] " + toPrint + L"\n";
+    if (options.verbose) {
+        std::wcout << Print;
+    }
+    addToLog(Print);
+}
+void warn(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[WARN] " + toPrint + L"\n";
+    std::wcout << Print;
+    addToLog(Print);
+}
+void error(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[ERROR] " + toPrint + L"\n";
+    std::wcout << Print;
+    addToLog(Print);
+}
+void fatal(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[FATAL] " + toPrint + L"\n";
+    std::wcout << Print;
+    addToLog(Print);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    std::exit(1);
+}
+void except(const std::wstring& toPrint) {
+    std::wstring Print = Utils::ToWString(getDate()) + L"[EXCEP] " + toPrint + L"\n";
+    std::wcout << Print;
     addToLog(Print);
 }

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -120,7 +120,7 @@ std::string HTTP::Post(const std::string& IP, const std::string& Fields) {
     return Ret;
 }
 
-bool HTTP::Download(const std::string& IP, const std::string& Path) {
+bool HTTP::Download(const std::string& IP, const std::wstring& Path) {
     static std::mutex Lock;
     std::scoped_lock Guard(Lock);
 
@@ -138,7 +138,7 @@ bool HTTP::Download(const std::string& IP, const std::string& Path) {
         File.close();
         info("Download Complete!");
     } else {
-        error("Failed to open file directory: " + Path);
+        error(L"Failed to open file directory: " + Path);
         return false;
     }
 

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -299,68 +299,6 @@ void InvalidResource(const std::string& File) {
     Terminate = true;
 }
 
-std::string GetSha256HashReallyFast(const std::string& filename) {
-    try {
-        EVP_MD_CTX* mdctx;
-        const EVP_MD* md;
-        uint8_t sha256_value[EVP_MAX_MD_SIZE];
-        md = EVP_sha256();
-        if (md == nullptr) {
-            throw std::runtime_error("EVP_sha256() failed");
-        }
-
-        mdctx = EVP_MD_CTX_new();
-        if (mdctx == nullptr) {
-            throw std::runtime_error("EVP_MD_CTX_new() failed");
-        }
-        if (!EVP_DigestInit_ex2(mdctx, md, NULL)) {
-            EVP_MD_CTX_free(mdctx);
-            throw std::runtime_error("EVP_DigestInit_ex2() failed");
-        }
-
-        std::ifstream stream(filename, std::ios::binary);
-
-        const size_t FileSize = std::filesystem::file_size(filename);
-        size_t Read = 0;
-        std::vector<char> Data;
-        while (Read < FileSize) {
-            Data.resize(size_t(std::min<size_t>(FileSize - Read, 4096)));
-            size_t RealDataSize = Data.size();
-            stream.read(Data.data(), std::streamsize(Data.size()));
-            if (stream.eof() || stream.fail()) {
-                RealDataSize = size_t(stream.gcount());
-            }
-            Data.resize(RealDataSize);
-            if (RealDataSize == 0) {
-                break;
-            }
-            if (RealDataSize > 0 && !EVP_DigestUpdate(mdctx, Data.data(), Data.size())) {
-                EVP_MD_CTX_free(mdctx);
-                throw std::runtime_error("EVP_DigestUpdate() failed");
-            }
-            Read += RealDataSize;
-        }
-        unsigned int sha256_len = 0;
-        if (!EVP_DigestFinal_ex(mdctx, sha256_value, &sha256_len)) {
-            EVP_MD_CTX_free(mdctx);
-            throw std::runtime_error("EVP_DigestFinal_ex() failed");
-        }
-        EVP_MD_CTX_free(mdctx);
-
-        std::string result;
-        for (size_t i = 0; i < sha256_len; i++) {
-            char buf[3];
-            sprintf(buf, "%02x", sha256_value[i]);
-            buf[2] = 0;
-            result += buf;
-        }
-        return result;
-    } catch (const std::exception& e) {
-        error("Sha256 hashing of '" + filename + "' failed: " + e.what());
-        return "";
-    }
-}
-
 struct ModInfo {
     static std::pair<bool, std::vector<ModInfo>> ParseModInfosFromPacket(const std::string& packet) {
         bool success = false;
@@ -431,12 +369,12 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
         }
         auto FileName = std::filesystem::path(ModInfoIter->FileName).stem().string() + "-" + ModInfoIter->Hash.substr(0, 8) + std::filesystem::path(ModInfoIter->FileName).extension().string();
         auto PathToSaveTo = (fs::path(CachingDirectory) / FileName).string();
-        if (fs::exists(PathToSaveTo) && GetSha256HashReallyFast(PathToSaveTo) == ModInfoIter->Hash) {
+        if (fs::exists(PathToSaveTo) && Utils::GetSha256HashReallyFast(PathToSaveTo) == ModInfoIter->Hash) {
             debug("Mod '" + FileName + "' found in cache");
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
             try {
-                if (!fs::exists(GetGamePath() + "mods/multiplayer")) {
-                    fs::create_directories(GetGamePath() + "mods/multiplayer");
+                if (!fs::exists(GetGamePath() + L"mods/multiplayer")) {
+                    fs::create_directories(GetGamePath() + L"mods/multiplayer");
                 }
                 auto modname = ModInfoIter->FileName;
 #if defined(__linux__)
@@ -494,8 +432,8 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
             }
         } while (fs::file_size(PathToSaveTo) != ModInfoIter->FileSize && !Terminate);
         if (!Terminate) {
-            if (!fs::exists(GetGamePath() + "mods/multiplayer")) {
-                fs::create_directories(GetGamePath() + "mods/multiplayer");
+            if (!fs::exists(GetGamePath() + L"mods/multiplayer")) {
+                fs::create_directories(GetGamePath() + L"mods/multiplayer");
             }
 
 // Linux version of the game doesnt support uppercase letters in mod names
@@ -593,8 +531,8 @@ void SyncResources(SOCKET Sock) {
                 UpdateUl(false, std::to_string(Pos) + "/" + std::to_string(Amount) + ": " + PathToSaveTo.substr(PathToSaveTo.find_last_of('/')));
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 try {
-                    if (!fs::exists(GetGamePath() + "mods/multiplayer")) {
-                        fs::create_directories(GetGamePath() + "mods/multiplayer");
+                    if (!fs::exists(GetGamePath() + L"mods/multiplayer")) {
+                        fs::create_directories(GetGamePath() + L"mods/multiplayer");
                     }
                     auto modname = PathToSaveTo.substr(PathToSaveTo.find_last_of('/'));
 #if defined(__linux__)
@@ -603,8 +541,8 @@ void SyncResources(SOCKET Sock) {
                         c = ::tolower(c);
                     }
 #endif
-                    auto name = GetGamePath() + "mods/multiplayer" + modname;
-                    auto tmp_name = name + ".tmp";
+                    auto name = GetGamePath() + L"mods/multiplayer" + Utils::ToWString(modname);
+                    auto tmp_name = name + L".tmp";
                     fs::copy_file(PathToSaveTo, tmp_name, fs::copy_options::overwrite_existing);
                     fs::rename(tmp_name, name);
                 } catch (std::exception& e) {
@@ -650,8 +588,8 @@ void SyncResources(SOCKET Sock) {
             }
         } while (fs::file_size(PathToSaveTo) != std::stoull(*FS) && !Terminate);
         if (!Terminate) {
-            if (!fs::exists(GetGamePath() + "mods/multiplayer")) {
-                fs::create_directories(GetGamePath() + "mods/multiplayer");
+            if (!fs::exists(GetGamePath() + L"mods/multiplayer")) {
+                fs::create_directories(GetGamePath() + L"mods/multiplayer");
             }
 
 // Linux version of the game doesnt support uppercase letters in mod names
@@ -661,7 +599,7 @@ void SyncResources(SOCKET Sock) {
             }
 #endif
 
-            fs::copy_file(PathToSaveTo, GetGamePath() + "mods/multiplayer" + FName, fs::copy_options::overwrite_existing);
+            fs::copy_file(PathToSaveTo, GetGamePath() + L"mods/multiplayer" + Utils::ToWString(FName), fs::copy_options::overwrite_existing);
         }
         WaitForConfirm();
     }

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -24,7 +24,7 @@
 #define MAX_VALUE_NAME 16383
 
 int TraceBack = 0;
-std::string GameDir;
+std::wstring GameDir;
 
 void lowExit(int code) {
     TraceBack = 0;
@@ -34,7 +34,7 @@ void lowExit(int code) {
     exit(2);
 }
 
-std::string GetGameDir() {
+std::wstring GetGameDir() {
 #if defined(_WIN32)
     return GameDir.substr(0, GameDir.find_last_of('\\'));
 #elif defined(__linux__)
@@ -45,8 +45,8 @@ std::string GetGameDir() {
 LONG OpenKey(HKEY root, const char* path, PHKEY hKey) {
     return RegOpenKeyEx(root, reinterpret_cast<LPCSTR>(path), 0, KEY_READ, hKey);
 }
-std::string QueryKey(HKEY hKey, int ID) {
-    TCHAR achKey[MAX_KEY_LENGTH]; // buffer for subkey name
+std::wstring QueryKey(HKEY hKey, int ID) {
+    wchar_t* achKey; // buffer for subkey name
     DWORD cbName; // size of name string
     TCHAR achClass[MAX_PATH] = TEXT(""); // buffer for class name
     DWORD cchClassName = MAX_PATH; // size of class string
@@ -61,7 +61,7 @@ std::string QueryKey(HKEY hKey, int ID) {
 
     DWORD i, retCode;
 
-    TCHAR achValue[MAX_VALUE_NAME];
+    wchar_t* achValue = new wchar_t[MAX_VALUE_NAME];
     DWORD cchValue = MAX_VALUE_NAME;
 
     retCode = RegQueryInfoKey(
@@ -83,9 +83,9 @@ std::string QueryKey(HKEY hKey, int ID) {
     if (cSubKeys) {
         for (i = 0; i < cSubKeys; i++) {
             cbName = MAX_KEY_LENGTH;
-            retCode = RegEnumKeyEx(hKey, i, achKey, &cbName, nullptr, nullptr, nullptr, &ftLastWriteTime);
+            retCode = RegEnumKeyExW(hKey, i, achKey, &cbName, nullptr, nullptr, nullptr, &ftLastWriteTime);
             if (retCode == ERROR_SUCCESS) {
-                if (strcmp(achKey, "Steam App 284160") == 0) {
+                if (wcscmp(achKey, L"Steam App 284160") == 0) {
                     return achKey;
                 }
             }
@@ -95,36 +95,37 @@ std::string QueryKey(HKEY hKey, int ID) {
         for (i = 0, retCode = ERROR_SUCCESS; i < cValues; i++) {
             cchValue = MAX_VALUE_NAME;
             achValue[0] = '\0';
-            retCode = RegEnumValue(hKey, i, achValue, &cchValue, nullptr, nullptr, nullptr, nullptr);
+            retCode = RegEnumValueW(hKey, i, achValue, &cchValue, nullptr, nullptr, nullptr, nullptr);
             if (retCode == ERROR_SUCCESS) {
                 DWORD lpData = cbMaxValueData;
                 buffer[0] = '\0';
-                LONG dwRes = RegQueryValueEx(hKey, achValue, nullptr, nullptr, buffer, &lpData);
-                std::string data = (char*)(buffer);
-                std::string key = achValue;
+                LONG dwRes = RegQueryValueExW(hKey, achValue, nullptr, nullptr, buffer, &lpData);
+                std::wstring data = (wchar_t*)(buffer);
+                std::wstring key = achValue;
+
 
                 switch (ID) {
                 case 1:
-                    if (key == "SteamExe") {
-                        auto p = data.find_last_of("/\\");
+                    if (key == L"SteamExe") {
+                        auto p = data.find_last_of(L"/\\");
                         if (p != std::string::npos) {
                             return data.substr(0, p);
                         }
                     }
                     break;
                 case 2:
-                    if (key == "Name" && data == "BeamNG.drive")
+                    if (key == L"Name" && data == L"BeamNG.drive")
                         return data;
                     break;
                 case 3:
-                    if (key == "rootpath")
+                    if (key == L"rootpath")
                         return data;
                     break;
                 case 4:
-                    if (key == "userpath_override")
+                    if (key == L"userpath_override")
                         return data;
                 case 5:
-                    if (key == "Local AppData")
+                    if (key == L"Local AppData")
                         return data;
                 default:
                     break;
@@ -132,8 +133,9 @@ std::string QueryKey(HKEY hKey, int ID) {
             }
         }
     }
+    delete[] achValue;
     delete[] buffer;
-    return "";
+    return L"";
 }
 #endif
 
@@ -160,7 +162,7 @@ void FileList(std::vector<std::string>& a, const std::string& Path) {
 }
 void LegitimacyCheck() {
 #if defined(_WIN32)
-    std::string Result;
+    std::wstring Result;
     std::string K3 = R"(Software\BeamNG\BeamNG.drive)";
     HKEY hKey;
     LONG dwRegOPenKey = OpenKey(HKEY_CURRENT_USER, K3.c_str(), &hKey);
@@ -193,11 +195,12 @@ void LegitimacyCheck() {
     }
 #endif
 }
-std::string CheckVer(const std::string& dir) {
+std::string CheckVer(const std::wstring& dir) {
+    std::string temp;
 #if defined(_WIN32)
-    std::string temp, Path = dir + "\\integrity.json";
+    std::wstring Path = dir + L"\\integrity.json";
 #elif defined(__linux__)
-    std::string temp, Path = dir + "/integrity.json";
+    std::wstring Path = dir + L"/integrity.json";
 #endif
     std::ifstream f(Path.c_str(), std::ios::binary);
     int Size = int(std::filesystem::file_size(Path));

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -20,13 +20,14 @@
 #include "Http.h"
 #include "Logger.h"
 #include "Network/network.hpp"
+#include "Options.h"
 #include "Security/Init.h"
 #include "Startup.h"
+#include "Utils.h"
 #include "hashpp.h"
 #include <filesystem>
 #include <fstream>
 #include <thread>
-#include "Options.h"
 
 extern int TraceBack;
 int ProxyPort = 0;
@@ -73,11 +74,11 @@ Version::Version(const std::array<uint8_t, 3>& v)
     : Version(v[0], v[1], v[2]) {
 }
 
-std::string GetEN() {
+std::wstring GetEN() {
 #if defined(_WIN32)
-    return "BeamMP-Launcher.exe";
+    return L"BeamMP-Launcher.exe";
 #elif defined(__linux__)
-    return "BeamMP-Launcher";
+    return L"BeamMP-Launcher";
 #endif
 }
 
@@ -88,34 +89,34 @@ std::string GetPatch() {
     return ".2";
 }
 
-std::string GetEP(const char* P) {
-    static std::string Ret = [&]() {
-        std::string path(P);
-        return path.substr(0, path.find_last_of("\\/") + 1);
+std::wstring GetEP(const wchar_t* P) {
+    static std::wstring Ret = [&]() {
+        std::wstring path(P);
+        return path.substr(0, path.find_last_of(L"\\/") + 1);
     }();
     return Ret;
 }
 #if defined(_WIN32)
 void ReLaunch() {
-    std::string Arg;
+    std::wstring Arg;
     for (int c = 2; c <= options.argc; c++) {
-        Arg += options.argv[c - 1];
-        Arg += " ";
+        Arg += Utils::ToWString(options.argv[c - 1]);
+        Arg += L" ";
     }
     info("Relaunch!");
     system("cls");
-    ShellExecute(nullptr, "runas", (GetEP() + GetEN()).c_str(), Arg.c_str(), nullptr, SW_SHOWNORMAL);
+    ShellExecuteW(nullptr, L"runas", (GetEP() + GetEN()).c_str(), Arg.c_str(), nullptr, SW_SHOWNORMAL);
     ShowWindow(GetConsoleWindow(), 0);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     exit(1);
 }
 void URelaunch() {
-    std::string Arg;
+    std::wstring Arg;
     for (int c = 2; c <= options.argc; c++) {
-        Arg += options.argv[c - 1];
-        Arg += " ";
+        Arg += Utils::ToWString(options.argv[c - 1]);
+        Arg += L" ";
     }
-    ShellExecute(nullptr, "open", (GetEP() + GetEN()).c_str(), Arg.c_str(), nullptr, SW_SHOWNORMAL);
+    ShellExecuteW(nullptr, L"open", (GetEP() + GetEN()).c_str(), Arg.c_str(), nullptr, SW_SHOWNORMAL);
     ShowWindow(GetConsoleWindow(), 0);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     exit(1);
@@ -150,16 +151,16 @@ void URelaunch() {
 
 void CheckName() {
 #if defined(_WIN32)
-    std::string DN = GetEN(), CDir = options.executable_name, FN = CDir.substr(CDir.find_last_of('\\') + 1);
+    std::wstring DN = GetEN(), CDir = Utils::ToWString(options.executable_name), FN = CDir.substr(CDir.find_last_of('\\') + 1);
 #elif defined(__linux__)
-    std::string DN = GetEN(), CDir = options.executable_name, FN = CDir.substr(CDir.find_last_of('/') + 1);
+    std::wstring DN = GetEN(), CDir = Utils::ToWString(options.executable_name), FN = CDir.substr(CDir.find_last_of('/') + 1);
 #endif
     if (FN != DN) {
         if (fs::exists(DN))
-            remove(DN.c_str());
+            _wremove(DN.c_str());
         if (fs::exists(DN))
             ReLaunch();
-        std::rename(FN.c_str(), DN.c_str());
+        _wrename(FN.c_str(), DN.c_str());
         URelaunch();
     }
 }
@@ -170,9 +171,9 @@ void CheckForUpdates(const std::string& CV) {
         "https://backend.beammp.com/version/launcher?branch=" + Branch + "&pk=" + PublicKey);
 
     transform(LatestHash.begin(), LatestHash.end(), LatestHash.begin(), ::tolower);
-    std::string EP(GetEP() + GetEN()), Back(GetEP() + "BeamMP-Launcher.back");
+    std::wstring EP(GetEP() + GetEN()), Back(GetEP() + L"BeamMP-Launcher.back");
 
-    std::string FileHash = hashpp::get::getFileHash(hashpp::ALGORITHMS::SHA2_256, EP);
+    std::string FileHash = Utils::GetSha256HashReallyFast(EP);
 
     if (FileHash != LatestHash && IsOutdated(Version(VersionStrToInts(GetVer() + GetPatch())), Version(VersionStrToInts(LatestVersion)))) {
         if (!options.no_update) {
@@ -251,7 +252,7 @@ size_t DirCount(const std::filesystem::path& path) {
     return (size_t)std::distance(std::filesystem::directory_iterator { path }, std::filesystem::directory_iterator {});
 }
 
-void CheckMP(const std::string& Path) {
+void CheckMP(const std::wstring& Path) {
     if (!fs::exists(Path))
         return;
     size_t c = DirCount(fs::path(Path));
@@ -271,7 +272,7 @@ void CheckMP(const std::string& Path) {
 }
 
 void EnableMP() {
-    std::string File(GetGamePath() + "mods/db.json");
+    std::wstring File(GetGamePath() + L"mods/db.json");
     if (!fs::exists(File))
         return;
     auto Size = fs::file_size(File);
@@ -294,18 +295,18 @@ void EnableMP() {
                 ofs << d.dump();
                 ofs.close();
             } else {
-                error("Failed to write " + File);
+                error(L"Failed to write " + File);
             }
         }
     }
 }
 
-void PreGame(const std::string& GamePath) {
+void PreGame(const std::wstring& GamePath) {
     std::string GameVer = CheckVer(GamePath);
     info("Game Version : " + GameVer);
 
-    CheckMP(GetGamePath() + "mods/multiplayer");
-    info("Game user path: " + GetGamePath());
+    CheckMP(GetGamePath() + L"mods/multiplayer");
+    info(L"Game user path: " + GetGamePath());
 
     if (!options.no_download) {
         std::string LatestHash = HTTP::Get("https://backend.beammp.com/sha/mod?branch=" + Branch + "&pk=" + PublicKey);
@@ -315,21 +316,21 @@ void PreGame(const std::string& GamePath) {
             LatestHash.end());
 
         try {
-            if (!fs::exists(GetGamePath() + "mods/multiplayer")) {
-                fs::create_directories(GetGamePath() + "mods/multiplayer");
+            if (!fs::exists(GetGamePath() + L"mods/multiplayer")) {
+                fs::create_directories(GetGamePath() + L"mods/multiplayer");
             }
             EnableMP();
         } catch (std::exception& e) {
             fatal(e.what());
         }
 #if defined(_WIN32)
-        std::string ZipPath(GetGamePath() + R"(mods\multiplayer\BeamMP.zip)");
+        std::wstring ZipPath(GetGamePath() + LR"(mods\multiplayer\BeamMP.zip)");
 #elif defined(__linux__)
         // Linux version of the game cant handle mods with uppercase names
-        std::string ZipPath(GetGamePath() + R"(mods/multiplayer/beammp.zip)");
+        std::wstring ZipPath(GetGamePath() + LR"(mods/multiplayer/beammp.zip)");
 #endif
 
-        std::string FileHash = hashpp::get::getFileHash(hashpp::ALGORITHMS::SHA2_256, ZipPath);
+        std::string FileHash = Utils::GetSha256HashReallyFast(ZipPath);
 
         if (FileHash != LatestHash) {
             info("Downloading BeamMP Update " + LatestHash);
@@ -339,7 +340,7 @@ void PreGame(const std::string& GamePath) {
                 ZipPath);
         }
 
-        std::string Target(GetGamePath() + "mods/unpacked/beammp");
+        std::wstring Target(GetGamePath() + L"mods/unpacked/beammp");
 
         if (fs::is_directory(Target)) {
             fs::remove_all(Target);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "Network/network.hpp"
 #include "Security/Init.h"
 #include "Startup.h"
+#include "Utils.h"
 #include <curl/curl.h>
 #include <iostream>
 #include <thread>
@@ -38,7 +39,7 @@ int main(int argc, const char** argv) try {
 
     curl_global_init(CURL_GLOBAL_ALL);
 
-    GetEP(argv[0]);
+    GetEP(Utils::ToWString(std::string(argv[0])).c_str());
 
     InitLog();
     ConfigInit();


### PR DESCRIPTION
This PR changes everything relating to file system paths to use std::wstring instead of std::string. This allows for non-latin characters to be in the user's path, for example in their windows username.

- [ ] Convert windows code to use wstring
- [ ] Convert linux code to use wstring

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
