### PR TITLE
Fix recv return type and better download error handling

### DIFF
--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -141,7 +141,7 @@ void GetServerInfo(std::string Data) {
     const std::string buffer = ([&]() -> std::string {
         int32_t Header;
         std::vector<char> data(sizeof(Header));
-        int32_t Temp = recv(ISock, data.data(), sizeof(Header), MSG_WAITALL);
+        int Temp = recv(ISock, data.data(), sizeof(Header), MSG_WAITALL);
 
         auto checkBytes = ([&](const int32_t bytes) -> bool {
             if (bytes == 0) {
@@ -352,7 +352,8 @@ void Parse(std::string Data, SOCKET CSocket) {
 }
 void GameHandler(SOCKET Client) {
     CoreSocket = Client;
-    int32_t Size, Temp, Rcv;
+    int32_t Size, Rcv;
+    int Temp;
     char Header[10] = { 0 };
     do {
         Rcv = 0;

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -262,7 +262,8 @@ void TCPGameServer(const std::string& IP, int Port) {
             NetMainThread = std::make_unique<std::thread>(NetMain, IP, Port);
             CServer = false;
         }
-        int32_t Size, Temp, Rcv;
+        int32_t Size, Rcv;
+        int Temp;
         char Header[10] = { 0 };
 
         // Read byte by byte until '>' is rcved then get the size and read based on it

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -165,7 +165,7 @@ std::vector<char> TCPRcvRaw(SOCKET Sock, uint64_t& GRcv, uint64_t Size) {
         // receive at most some MB at a time
         int Len = std::min(int(Size - Rcv), 1 * 1024 * 1024);
         int Temp = recv(Sock, &File[Rcv], Len, MSG_WAITALL);
-        if (Temp < 1) {
+        if (Temp == -1 || Temp == 0) {
             debug("Recv returned: " + std::to_string(Temp));
             if (Temp == -1) {
                 error("Socket error during download: " + std::to_string(WSAGetLastError()));

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -164,9 +164,12 @@ std::vector<char> TCPRcvRaw(SOCKET Sock, uint64_t& GRcv, uint64_t Size) {
     do {
         // receive at most some MB at a time
         int Len = std::min(int(Size - Rcv), 1 * 1024 * 1024);
-        int32_t Temp = recv(Sock, &File[Rcv], Len, MSG_WAITALL);
+        int Temp = recv(Sock, &File[Rcv], Len, MSG_WAITALL);
         if (Temp < 1) {
-            info(std::to_string(Temp));
+            debug("Recv returned: " + std::to_string(Temp));
+            if (Temp == -1) {
+                error("Socket error during download: " + std::to_string(WSAGetLastError()));
+            }
             UUl("Socket Closed Code 1");
             KillSocket(Sock);
             Terminate = true;

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -180,8 +180,8 @@ std::vector<char> TCPRcvRaw(SOCKET Sock, uint64_t& GRcv, uint64_t Size) {
 
         auto end = std::chrono::high_resolution_clock::now();
         auto difference = end - start;
-        float bits_per_s = float(Rcv * 8) / float(std::chrono::duration_cast<std::chrono::milliseconds>(difference).count());
-        float megabits_per_s = bits_per_s / 1000;
+        double bits_per_s = double(Rcv * 8) / double(std::chrono::duration_cast<std::chrono::milliseconds>(difference).count());
+        double megabits_per_s = bits_per_s / 1000;
         DownloadSpeed = megabits_per_s;
         // every 8th iteration print the speed
         if (i % 8 == 0) {

--- a/src/Network/VehicleEvent.cpp
+++ b/src/Network/VehicleEvent.cpp
@@ -81,7 +81,8 @@ std::string TCPRcv(SOCKET Sock) {
         UUl("Invalid Socket");
         return "";
     }
-    int32_t Header, Temp;
+    int32_t Header;
+    int Temp;
     std::vector<char> Data(sizeof(Header));
     Temp = recv(Sock, Data.data(), sizeof(Header), MSG_WAITALL);
     if (!CheckBytes(Temp)) {


### PR DESCRIPTION
Fixes the recv return value type. This PR corrects the recv return value type from `int32_t` to `int`. Casting the return value from `int` to `int32_t` (Currently the case, changed by this pr) would in some cases, if the transmitted packet was large enough, flip the value causing it to be a high negative number, which recv will never return. This happens frequently when downloading big mods over a fast connection.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
