### PR TITLE
Notify user about missing protected mods

### DIFF
--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -380,6 +380,11 @@ struct ModInfo {
                     .Hash = entry["hash"],
                     .HashAlgorithm = entry["hash_algorithm"],
                 };
+
+                if (entry.contains("protected")) {
+                    modInfo.Protected = entry["protected"];
+                }
+
                 modInfos.push_back(modInfo);
                 success = true;
             }
@@ -393,6 +398,7 @@ struct ModInfo {
     size_t FileSize;
     std::string Hash;
     std::string HashAlgorithm;
+    bool Protected = false;
 };
 
 nlohmann::json modUsage = {};
@@ -544,6 +550,16 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
             WaitForConfirm();
             continue;
         }
+
+        if (ModInfoIter->Protected && false) {
+            std::string message = "Mod '" + ModInfoIter->FileName + "' is protected and therefore must be placed in the Resources/Caching folder manually here: " + fs::absolute(CachingDirectory).string();
+
+            error(message);
+            UUl(message);
+            Terminate = true;
+            return;
+        }
+
         CheckForDir();
         std::string FName = ModInfoIter->FileName;
         do {


### PR DESCRIPTION
Launcher implementation for https://github.com/BeamMP/BeamMP-Server/pull/430. This PR checks if mods are protected, and if a mod is missing the launcher will notify the user about it and give them instructions on how to resolve it.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
