### PR TITLE
Implement DeleteDuplicateMods option

### DIFF
--- a/include/Network/network.hpp
+++ b/include/Network/network.hpp
@@ -30,6 +30,7 @@ extern uint64_t UDPSock;
 extern uint64_t TCPSock;
 extern std::string Branch;
 extern std::string CachingDirectory;
+extern bool deleteDuplicateMods;
 extern bool TCPTerminate;
 extern std::string LastIP;
 extern std::string MStatus;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -15,6 +15,7 @@ namespace fs = std::filesystem;
 
 std::string Branch;
 std::string CachingDirectory = "./Resources";
+bool deleteDuplicateMods = false;
 
 void ParseConfig(const nlohmann::json& d) {
     if (d["Port"].is_number()) {
@@ -42,6 +43,11 @@ void ParseConfig(const nlohmann::json& d) {
         options.no_launch = dev;
         options.no_update = dev;
     }
+
+    if (d.contains(("DeleteDuplicateMods")) && d["DeleteDuplicateMods"].is_boolean()) {
+        deleteDuplicateMods = d["DeleteDuplicateMods"].get<bool>();
+    }
+
 }
 
 void ConfigInit() {

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -478,8 +478,9 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
     std::vector<std::pair<std::string, std::filesystem::path>> CachedMods = {};
     if (deleteDuplicateMods) {
         for (const auto& entry : fs::directory_iterator(CachingDirectory)) {
-            if (entry.is_regular_file() && entry.path().extension() == ".zip" && entry.path().filename().string().length() > 10) {
-                CachedMods.push_back(std::make_pair(entry.path().filename().string().substr(0, entry.path().filename().string().length() - 13) + ".zip", entry.path()));
+            const std::string filename = entry.path().filename().string();
+            if (entry.is_regular_file() && entry.path().extension() == ".zip" && filename.length() > 10) {
+                CachedMods.push_back(std::make_pair(filename.substr(0, filename.length() - 13) + ".zip", entry.path()));
             }
         }
     }
@@ -490,7 +491,9 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
         ++ModNo;
         if (deleteDuplicateMods) {
             for (auto& CachedMod : CachedMods) {
-                if (CachedMod.first == ModInfoIter->FileName && CachedMod.second.stem().string() + ".zip" != std::filesystem::path(ModInfoIter->FileName).stem().string() + "-" + ModInfoIter->Hash.substr(0, 8) + ".zip") {
+                const bool cachedModExists = CachedMod.first == ModInfoIter->FileName;
+                const bool cachedModIsNotNewestVersion = CachedMod.second.stem().string() + ".zip" != std::filesystem::path(ModInfoIter->FileName).stem().string() + "-" + ModInfoIter->Hash.substr(0, 8) + ".zip";
+                if (cachedModExists && cachedModIsNotNewestVersion) {
                     debug("Found duplicate mod '" + CachedMod.second.stem().string() + ".zip" + "' in cache, removing it");
                     std::filesystem::remove(CachedMod.second);
                     break;


### PR DESCRIPTION
Adds `DeleteDuplicateMods` option to the launcher config which, well, deletes mods with the same name if their hashes mismatch. Useful for development where client mod hashes can frequently change.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
