### PR TITLE
Check if unpacked BeamMP has a .git folder before deleting it

### DIFF
--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -341,7 +341,7 @@ void PreGame(const std::string& GamePath) {
 
         std::string Target(GetGamePath() + "mods/unpacked/beammp");
 
-        if (fs::is_directory(Target)) {
+        if (fs::is_directory(Target) && !fs::is_directory(Target + "/.git")) {
             fs::remove_all(Target);
         }
     }


### PR DESCRIPTION
This PR makes it so that the launcher will first check for the presence of a .git folder before deleting the unpacked BeamMP directory.
This is useful when you're working on the BeamMP mod and you accidentally start the launcher without dev mode. (This has happened to me more times than I would like to admit.)

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
