### PR TITLE
Add Debian legacy Steam installation path

### DIFF
--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -187,6 +187,7 @@ void LegitimacyCheck() {
     // Right now only steam is supported
     std::vector<std::filesystem::path> steamappsCommonPaths = {
         ".steam/root/steamapps", // default
+        ".steam/steam/steamapps", // Legacy Steam installations
         ".var/app/com.valvesoftware.Steam/.steam/root/steamapps", // flatpak
         "snap/steam/common/.local/share/Steam/steamapps" // snap
     };


### PR DESCRIPTION
Current Steam installations seem to have a much cleaner filesystem layout on Debian while older ones look quite different.

Older Debian installations ~/.steam/root points to ~/.steam while newer ones point to ~/.steam/debian-installation and hence BeamMP cannot find integrity.json. 'steamapps' is at ~/.steam/debian-installation in newer installations.

On the older installations, 'steamapps' is at ~/.steam/steam/steamapps.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
