### PR TITLE
Workaround bom header

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -21,12 +21,14 @@
 #define beammp_fs_string std::wstring
 #define beammp_fs_char wchar_t
 #define beammp_wide(str) L##str
+#define beammp_stdout std::wcout
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
 #define beammp_fs_string std::string
 #define beammp_fs_char char
 #define beammp_wide(str) str
+#define beammp_stdout std::cout
 #endif
 
 namespace Utils {

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -57,36 +57,36 @@ void addToLog(const std::wstring& Line) {
 }
 void info(const std::string& toPrint) {
     std::string Print = getDate() + "[INFO] " + toPrint + "\n";
-    std::cout << Print;
+    std::wcout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void debug(const std::string& toPrint) {
     std::string Print = getDate() + "[DEBUG] " + toPrint + "\n";
     if (options.verbose) {
-        std::cout << Print;
+        std::wcout << Utils::ToWString(Print);
     }
     addToLog(Print);
 }
 void warn(const std::string& toPrint) {
     std::string Print = getDate() + "[WARN] " + toPrint + "\n";
-    std::cout << Print;
+    std::wcout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void error(const std::string& toPrint) {
     std::string Print = getDate() + "[ERROR] " + toPrint + "\n";
-    std::cout << Print;
+    std::wcout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void fatal(const std::string& toPrint) {
     std::string Print = getDate() + "[FATAL] " + toPrint + "\n";
-    std::cout << Print;
+    std::wcout << Utils::ToWString(Print);
     addToLog(Print);
     std::this_thread::sleep_for(std::chrono::seconds(5));
     std::exit(1);
 }
 void except(const std::string& toPrint) {
     std::string Print = getDate() + "[EXCEP] " + toPrint + "\n";
-    std::cout << Print;
+    std::wcout << Utils::ToWString(Print);
     addToLog(Print);
 }
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -57,36 +57,36 @@ void addToLog(const std::wstring& Line) {
 }
 void info(const std::string& toPrint) {
     std::string Print = getDate() + "[INFO] " + toPrint + "\n";
-    std::wcout << Utils::ToWString(Print);
+    beammp_stdout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void debug(const std::string& toPrint) {
     std::string Print = getDate() + "[DEBUG] " + toPrint + "\n";
     if (options.verbose) {
-        std::wcout << Utils::ToWString(Print);
+        beammp_stdout << Utils::ToWString(Print);
     }
     addToLog(Print);
 }
 void warn(const std::string& toPrint) {
     std::string Print = getDate() + "[WARN] " + toPrint + "\n";
-    std::wcout << Utils::ToWString(Print);
+    beammp_stdout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void error(const std::string& toPrint) {
     std::string Print = getDate() + "[ERROR] " + toPrint + "\n";
-    std::wcout << Utils::ToWString(Print);
+    beammp_stdout << Utils::ToWString(Print);
     addToLog(Print);
 }
 void fatal(const std::string& toPrint) {
     std::string Print = getDate() + "[FATAL] " + toPrint + "\n";
-    std::wcout << Utils::ToWString(Print);
+    beammp_stdout << Utils::ToWString(Print);
     addToLog(Print);
     std::this_thread::sleep_for(std::chrono::seconds(5));
     std::exit(1);
 }
 void except(const std::string& toPrint) {
     std::string Print = getDate() + "[EXCEP] " + toPrint + "\n";
-    std::wcout << Utils::ToWString(Print);
+    beammp_stdout << Utils::ToWString(Print);
     addToLog(Print);
 }
 

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -177,6 +177,10 @@ void LegitimacyCheck() {
             std::string contents((std::istreambuf_iterator(beamngIni)), std::istreambuf_iterator<char>());
             beamngIni.close();
 
+            if (contents.size() >= 3 && (unsigned char)contents[0] == 0xEF && (unsigned char)contents[1] == 0xBB && (unsigned char)contents[2] == 0xBF) {
+                contents = contents.substr(3);
+            }
+
             auto ini = Utils::ParseINI(contents);
             if (ini.empty())
                 lowExit(3);

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -269,6 +269,8 @@ void LinuxPatch() {
 
 void InitLauncher() {
     SetConsoleTitleA(("BeamMP Launcher v" + std::string(GetVer()) + GetPatch()).c_str());
+    SetConsoleOutputCP(CP_UTF8);
+    _setmode(_fileno(stdout), _O_U8TEXT);
     debug("Launcher Version : " + GetVer() + GetPatch());
     CheckName();
     LinuxPatch();


### PR DESCRIPTION
This PR removes the utf8 bom encoding header which was causing issues. This PR also adds support for unicode characters in the terminal on windows.

For context it looks like the BeamNG launcher only encodes it with the utf8 header, which is what it's currently removing.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
