### PR TITLE
Adjust ini parser

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -120,13 +120,6 @@ namespace Utils {
             if (line.empty() || line[0] == ';' || line[0] == '#')
                 continue;
 
-            for (auto& c : line) {
-                if (c == '#' || c == ';') {
-                    line = line.substr(0, &c - &line[0]);
-                    break;
-                }
-            }
-
             auto invalidLineLog = [&]{
                 debug("Invalid INI line: " + line);
                 debug("Surrounding lines: \n" +


### PR DESCRIPTION
This PR removes mid-line ini comments which were causing issue because users had `#` and `;` in their file path.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
