### PR TITLE
Simple MacOS support

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -1,0 +1,46 @@
+name: CMake MacOS Build
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  macos-build:
+    runs-on: macos-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'true'
+      
+      - name: Restore artifacts, or run vcpkg, build and cache artifacts
+        uses: lukka/run-vcpkg@v7
+        id: runvcpkg
+        with:
+            vcpkgArguments: 'zlib:arm64-osx nlohmann-json:arm64-osx openssl:arm64-osx cpp-httplib[openssl]:arm64-osx curl:arm64-osx'
+            vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+            vcpkgGitCommitId: '40616a5e954f7be1077ef37db3fbddbd5dcd1ca6'
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{github.workspace}}/build-macos
+
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{github.workspace}}/build-macos
+        run: |
+          cmake $GITHUB_WORKSPACE \
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_TOOLCHAIN_FILE='${{ runner.workspace }}/b/vcpkg/scripts/buildsystems/vcpkg.cmake' \
+            -DCMAKE_OSX_ARCHITECTURES=arm64
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build-macos
+        shell: bash
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BeamMP-Launcher
+          path: ${{github.workspace}}/build-macos/BeamMP-Launcher

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -14,6 +14,11 @@ jobs:
         with:
             submodules: 'true'
       
+      - name: Configure macOS SDK
+        run: |
+          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
+      
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
         uses: lukka/run-vcpkg@v7
         id: runvcpkg

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cmake-build-release
 /*.sh
 /*.obj
 /*.exe
+.DS_Store/
 .cache/
 .https_debug/
 Launcher.cfg
@@ -13,3 +14,9 @@ bin/
 compile_commands.json
 key
 out/
+vcpkg_installed/
+
+build-linux/
+build-macos/
+build-windows/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (WIN32)
     find_package(OpenSSL REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE
             ZLIB::ZLIB OpenSSL::SSL OpenSSL::Crypto ws2_32 httplib::httplib nlohmann_json::nlohmann_json CURL::libcurl)
-elseif (UNIX)
+elseif (UNIX OR APPLE)
     find_package(ZLIB REQUIRED)
     find_package(OpenSSL REQUIRED)
     target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/include/Network/network.hpp
+++ b/include/Network/network.hpp
@@ -9,11 +9,13 @@
 #include <filesystem>
 #include <string>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include "linuxfixes.h"
+#if defined(__linux__)
 #include <bits/types/siginfo_t.h>
-#include <cstdint>
 #include <sys/ucontext.h>
+#endif
+#include <cstdint>
 #include <arpa/inet.h>
 #endif
 

--- a/include/Options.h
+++ b/include/Options.h
@@ -11,7 +11,7 @@
 struct Options {
 #if defined(_WIN32)
     std::string executable_name = "BeamMP-Launcher.exe";
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     std::string executable_name = "BeamMP-Launcher";
 #endif
     unsigned int port = 4444;

--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -214,12 +214,6 @@ void StartGame(std::string Dir) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
     exit(2);
 }
-#elif defined(__APPLE__)
-// macOS does not support game launching - StartGame is never called
-void StartGame(std::string Dir) {
-    // This function should never be called on macOS
-    error("Game launching is not supported on macOS");
-}
 #endif
 
 #if !defined(__APPLE__)

--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -224,7 +224,6 @@ void StartGame(std::string Dir) {
 
 #if !defined(__APPLE__)
 void InitGame(const beammp_fs_string& Dir) {
-
     if (!options.no_launch) {
         std::thread Game(StartGame, Dir);
         Game.detach();

--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -6,7 +6,7 @@
 
 #if defined(_WIN32)
 #include <shlobj.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "vdf_parser.hpp"
 #include <pwd.h>
 #include <spawn.h>
@@ -128,6 +128,18 @@ std::filesystem::path GetGamePath() {
     Path += "current/";
     return Path;
 }
+#elif defined(__APPLE__)
+std::filesystem::path GetGamePath() {
+    // Right now only steam is supported
+    struct passwd* pw = getpwuid(getuid());
+    std::string homeDir = pw->pw_dir;
+
+    std::string Path = homeDir + "/Library/Application Support/BeamNG/BeamNG.drive/";
+    std::string Ver = CheckVer(GetGameDir());
+    Ver = Ver.substr(0, Ver.find('.', Ver.find('.') + 1));
+    Path += "current/";
+    return Path;
+}
 #endif
 
 #if defined(_WIN32)
@@ -202,11 +214,22 @@ void StartGame(std::string Dir) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
     exit(2);
 }
+#elif defined(__APPLE__)
+// macOS does not support game launching - StartGame is never called
+void StartGame(std::string Dir) {
+    // This function should never be called on macOS
+    error("Game launching is not supported on macOS");
+}
 #endif
 
 void InitGame(const beammp_fs_string& Dir) {
+#if defined(__APPLE__)
+    // macOS does not support game launching
+    return;
+#else
     if (!options.no_launch) {
         std::thread Game(StartGame, Dir);
         Game.detach();
     }
+#endif
 }

--- a/src/GameStart.cpp
+++ b/src/GameStart.cpp
@@ -222,14 +222,12 @@ void StartGame(std::string Dir) {
 }
 #endif
 
+#if !defined(__APPLE__)
 void InitGame(const beammp_fs_string& Dir) {
-#if defined(__APPLE__)
-    // macOS does not support game launching
-    return;
-#else
+
     if (!options.no_launch) {
         std::thread Game(StartGame, Dir);
         Game.detach();
     }
-#endif
 }
+#endif

--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -13,7 +13,8 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <shellapi.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
+#include "linuxfixes.h"
 #include <cstring>
 #include <errno.h>
 #include <netdb.h>
@@ -481,19 +482,16 @@ int Handle(EXCEPTION_POINTERS* ep) {
 
 [[noreturn]] void CoreNetwork() {
     while (true) {
-#if not defined(__MINGW32__)
+#if defined(_WIN32) && not defined(__MINGW32__)
         __try {
-#endif
-
             CoreMain();
-
-#if not defined(__MINGW32__) and not defined(__linux__)
         } __except (Handle(GetExceptionInformation())) { }
-#elif not defined(__MINGW32__) and defined(__linux__)
-    }
-    catch (...) {
-        except("(Core) Code : " + std::string(strerror(errno)));
-    }
+#elif defined(__linux__) || defined(__APPLE__)
+        try {
+            CoreMain();
+        } catch (...) {
+            except("(Core) Code : " + std::string(strerror(errno)));
+        }
 #endif
 
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/Network/DNS.cpp
+++ b/src/Network/DNS.cpp
@@ -9,10 +9,11 @@
 
 #if defined(_WIN32)
 #include <winsock2.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "linuxfixes.h"
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <cstring>
 #endif
 
 #include "Logger.h"
@@ -33,10 +34,14 @@ std::string GetAddr(const std::string& IP) {
     host = gethostbyname(IP.c_str());
     if (!host) {
         error("DNS lookup failed! on " + IP);
+#if defined(_WIN32)
         WSACleanup();
+#endif
         return "DNS";
     }
     std::string Ret = inet_ntoa(*((struct in_addr*)host->h_addr));
+#if defined(_WIN32)
     WSACleanup();
+#endif
     return Ret;
 }

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -10,7 +10,7 @@
 #if defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "linuxfixes.h"
 #include <arpa/inet.h>
 #include <cstring>

--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -16,7 +16,8 @@
 
 #if defined(_WIN32)
 #include <ws2tcpip.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
+#include "linuxfixes.h"
 #include <arpa/inet.h>
 #include <cstring>
 #include <errno.h>

--- a/src/Network/VehicleData.cpp
+++ b/src/Network/VehicleData.cpp
@@ -10,7 +10,7 @@
 
 #if defined(_WIN32)
 #include <ws2tcpip.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "linuxfixes.h"
 #include <arpa/inet.h>
 #include <cstring>
@@ -65,7 +65,7 @@ void UDPRcv() {
     sockaddr_in FromServer {};
 #if defined(_WIN32)
     int clientLength = sizeof(FromServer);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     socklen_t clientLength = sizeof(FromServer);
 #endif
     ZeroMemory(&FromServer, clientLength);

--- a/src/Network/VehicleEvent.cpp
+++ b/src/Network/VehicleEvent.cpp
@@ -13,7 +13,8 @@
 
 #if defined(_WIN32)
 #include <ws2tcpip.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
+#include "linuxfixes.h"
 #include <arpa/inet.h>
 #include <cstring>
 #include <errno.h>

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -8,7 +8,7 @@
 #include <filesystem>
 #if defined(_WIN32)
 #include <shlobj_core.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "vdf_parser.hpp"
 #include <pwd.h>
 #include <unistd.h>
@@ -18,6 +18,7 @@
 #include "Utils.h"
 
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <thread>
 
@@ -38,7 +39,7 @@ void lowExit(int code) {
 beammp_fs_string GetGameDir() {
 #if defined(_WIN32)
     return GameDir.substr(0, GameDir.find_last_of('\\'));
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     return GameDir.substr(0, GameDir.find_last_of('/'));
 #endif
 }
@@ -278,6 +279,38 @@ void LegitimacyCheck() {
         error("The game directory was not found.");
         return;
     }
+#elif defined(__APPLE__)
+    // On macOS, ask the user to provide the game directory path
+    info("Please enter the path to your BeamNG.drive installation directory:");
+    info("Example: /Users/YourName/Library/Application Support/Steam/steamapps/common/BeamNG.drive");
+    std::cout << "Game directory path: ";
+    
+    std::string userPath;
+    std::getline(std::cin, userPath);
+    
+    // Remove trailing slash if present
+    if (!userPath.empty() && (userPath.back() == '/' || userPath.back() == '\\')) {
+        userPath.pop_back();
+    }
+    
+    std::filesystem::path gamePath(userPath);
+    
+    // Check if the path exists and contains integrity.json
+    if (!std::filesystem::exists(gamePath)) {
+        error("The specified path does not exist: " + userPath);
+        lowExit(8);
+        return;
+    }
+    
+    std::filesystem::path integrityPath = gamePath / "integrity.json";
+    if (!std::filesystem::exists(integrityPath)) {
+        error("The specified path does not appear to be a valid BeamNG.drive installation (integrity.json not found).");
+        lowExit(9);
+        return;
+    }
+    
+    GameDir = gamePath.string() + "/";
+    info("Game directory set to: " + GameDir);
 #endif
 }
 std::string CheckVer(const std::filesystem::path& dir) {

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -78,7 +78,7 @@ Version::Version(const std::array<uint8_t, 3>& v)
 beammp_fs_string GetEN() {
 #if defined(_WIN32)
     return L"BeamMP-Launcher.exe";
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     return "BeamMP-Launcher";
 #endif
 }
@@ -150,7 +150,7 @@ void URelaunch() {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     exit(1);
 }
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 void ReLaunch() {
     std::string Arg;
     for (int c = 2; c <= options.argc; c++) {
@@ -158,7 +158,11 @@ void ReLaunch() {
         Arg += " ";
     }
     info("Relaunch!");
+#if defined(__linux__)
     system("clear");
+#elif defined(__APPLE__)
+    system("clear");
+#endif
     int ret = execv((GetBP() / GetEN()).c_str(), const_cast<char**>(options.argv));
     if (ret < 0) {
         error(std::string("execv() failed with: ") + strerror(errno) + ". Failed to relaunch");
@@ -181,7 +185,7 @@ void URelaunch() {
 void CheckName() {
 #if defined(_WIN32)
     std::wstring DN = GetEN(), CDir = Utils::ToWString(options.executable_name), FN = CDir.substr(CDir.find_last_of('\\') + 1);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     std::string DN = GetEN(), CDir = options.executable_name, FN = CDir.substr(CDir.find_last_of('/') + 1);
 #endif
     if (FN != DN) {
@@ -280,7 +284,7 @@ void InitLauncher() {
     CheckLocalKey();
     CheckForUpdates(std::string(GetVer()) + GetPatch());
 }
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 
 void InitLauncher() {
     info("BeamMP Launcher v" + GetVer() + GetPatch());
@@ -367,8 +371,8 @@ void PreGame(const beammp_fs_string& GamePath) {
         }
 #if defined(_WIN32)
         std::wstring ZipPath(GetGamePath() / LR"(mods\multiplayer\BeamMP.zip)");
-#elif defined(__linux__)
-        // Linux version of the game cant handle mods with uppercase names
+#elif defined(__linux__) || defined(__APPLE__)
+        // Linux and macOS versions of the game cant handle mods with uppercase names
         std::string ZipPath(GetGamePath() / R"(mods/multiplayer/beammp.zip)");
 #endif
 

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -158,11 +158,7 @@ void ReLaunch() {
         Arg += " ";
     }
     info("Relaunch!");
-#if defined(__linux__)
     system("clear");
-#elif defined(__APPLE__)
-    system("clear");
-#endif
     int ret = execv((GetBP() / GetEN()).c_str(), const_cast<char**>(options.argv));
     if (ret < 0) {
         error(std::string("execv() failed with: ") + strerror(errno) + ". Failed to relaunch");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,9 @@ int main(int argc, const char** argv) try {
         error(std::string("Failed to start HTTP proxy: Some in-game functions may not work. Error: ") + e.what());
     }
     PreGame(GetGameDir());
-    InitGame(GetGameDir());
+    if (!defined(__APPLE__)) {
+        InitGame(GetGameDir());
+    }
     CoreNetwork();
 } catch (const std::exception& e) {
     error(std::string("Exception in main(): ") + e.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,9 @@ int main(int argc, const char** argv) try {
         error(std::string("Failed to start HTTP proxy: Some in-game functions may not work. Error: ") + e.what());
     }
     PreGame(GetGameDir());
-    if (!defined(__APPLE__)) {
+    #if !defined(__APPLE__)
         InitGame(GetGameDir());
-    }
+    #endif
     CoreNetwork();
 } catch (const std::exception& e) {
     error(std::string("Exception in main(): ") + e.what());


### PR DESCRIPTION
# This PR introduces initial macOS support.

This implementation is not finished yet and may require further improvements.

Adding macOS support does not require major changes to the launcher because of the existing Linux support. The main difficulty is handling the game path.

On macOS, BeamNG.drive is usually run through CrossOver, which adds multiple layers (Wine, bottles, custom directories). Because of this complexity, the game installation path cannot be reliably detected automatically.

The launcher still requires this path to function correctly, so it must currently be provided manually by the user.

A possible improvement would be to store the last known game path (for example in the Resources directory) to avoid asking for it again on future launches.

## Maintenance 

A new CI is setup to build the MacOS version of the launcher for us. If it fails, mention me and I’ll come to help fix the issue. Considering the limited number of macOS users for BeamMP, it can be fixed later if not done in time.

## Documentation 

If necessary, I can create some documentation on how to run BeamMP on macOS. Anyone needing help can then contact me.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
