### PR TITLE
linux: Use SO_REUSEADDR for #228

### DIFF
--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -175,6 +175,13 @@ SOCKET SetupListener() {
         WSACleanup();
         return -1;
     }
+#ifdef __linux__
+    // On linux the old socket can get stuck in time wait
+    const int reuse_addr = 1;
+    if (setsockopt(GSocket, SOL_SOCKET, SO_REUSEADDR, &reuse_addr, sizeof(int)) < 0) {
+        warn("(Proxy) setsockopt(SO_REUSEADDR) failed" + std::to_string(WSAGetLastError()));
+    }
+#endif
     iRes = bind(GSocket, result->ai_addr, (int)result->ai_addrlen);
     if (iRes == SOCKET_ERROR) {
         error("(Proxy) bind failed with error: " + std::to_string(WSAGetLastError()));


### PR DESCRIPTION
This fixes #228 by setting SO_REUSEADDR.  

With this change I can reconnect without closing & reopening the game.
```
[15/3/2026 19:55:57] [INFO] BeamMP Launcher v2.7.0
[15/3/2026 19:55:58] [INFO] Launcher version is up to date. Latest version: 2.7.0
[15/3/2026 19:55:58] [INFO] IMPORTANT: You MUST keep this window open to play BeamMP!
[15/3/2026 19:55:58] [INFO] Game Version : 0.38.4.0
[15/3/2026 19:55:58] [INFO] Game user path: /home/me/.local/share/BeamNG/BeamNG.drive/current/
[15/3/2026 19:56:03] [INFO] Game Connected!
[15/3/2026 19:57:28] [INFO] Attempting to authenticate...
[15/3/2026 19:57:29] [INFO] Authentication successful!
[15/3/2026 19:57:37] [INFO] Connecting to server
[15/3/2026 19:57:37] [INFO] Connected!
[15/3/2026 19:57:38] [INFO] Checking Resources...
[15/3/2026 19:57:38] [INFO] Syncing...
[15/3/2026 19:57:39] [INFO] Done!
[15/3/2026 20:01:32] [INFO] Connection Terminated!
[15/3/2026 20:01:32] [INFO] Connecting to server
[15/3/2026 20:01:33] [INFO] Connected!
[15/3/2026 20:01:34] [INFO] Terminated!
[15/3/2026 20:01:41] [WARN] Failed to close socket!
[15/3/2026 20:02:26] [WARN] Game Reconnecting...
[15/3/2026 20:02:27] [INFO] Game Connected!
[15/3/2026 20:02:43] [INFO] Connecting to server
[15/3/2026 20:02:43] [INFO] Connected!
[15/3/2026 20:02:44] [INFO] Checking Resources...
[15/3/2026 20:02:44] [INFO] Syncing...
[15/3/2026 20:02:44] [INFO] Done!
[15/3/2026 20:03:06] [WARN] Game Reconnecting...
[15/3/2026 20:03:07] [INFO] Game Connected!
[15/3/2026 20:03:09] [WARN] Game Reconnecting...
[15/3/2026 20:03:10] [ERROR] Game Closed! launcher closing soon
```