### PR TITLE
prevent GameSend send() call on invalid socket

### DIFF
--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -63,7 +63,7 @@ bool CheckBytes(uint32_t Bytes) {
 
 void GameSend(std::string_view Data) {
     if (!GConnected) {
-        debug("Tried to call GameSend but socket was not connected. Data: " + Data)
+        debug("Tried to call GameSend but socket was not connected. Data: " + std::string(Data));
         return;
     }
     static std::mutex Lock;

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -62,6 +62,8 @@ bool CheckBytes(uint32_t Bytes) {
 }
 
 void GameSend(std::string_view Data) {
+    if (!GConnected)
+        return;
     static std::mutex Lock;
     std::scoped_lock Guard(Lock);
     auto ToSend = Utils::PrependHeader<std::string_view>(Data);

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -62,8 +62,10 @@ bool CheckBytes(uint32_t Bytes) {
 }
 
 void GameSend(std::string_view Data) {
-    if (!GConnected)
+    if (!GConnected) {
+        debug("Tried to call GameSend but socket was not connected. Data: " + Data)
         return;
+    }
     static std::mutex Lock;
     std::scoped_lock Guard(Lock);
     auto ToSend = Utils::PrependHeader<std::string_view>(Data);


### PR DESCRIPTION
prevents WSAENOTSOCK by not allowing a `send()` call on an invalid/closed socket when the game client isn't connected

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.