### PR TITLE
Implement direct vehicle socket

### DIFF
--- a/include/Network/network.hpp
+++ b/include/Network/network.hpp
@@ -9,7 +9,6 @@
 #include <filesystem>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 #ifdef __linux__
 #include "linuxfixes.h"
@@ -61,7 +60,6 @@ void CoreSend(std::string data);
 int RecvWaitAll(int sockfd, char *buf, int len);
 void ServerSend(std::string Data, bool Rel);
 extern uint64_t DVSock;
-extern std::unordered_set<std::string> activeVehicles; // set of active serverVehicleIDs for checking if direct vehicle sockets are valid
 extern std::unordered_map<std::string, int> vehiclePortMap; // maps a serverVehicleID to the port of its vehicle socket
 void DVSend(std::string_view Data, int Port);
 void DVClientMain(const std::string& IP, int Port);

--- a/include/Network/network.hpp
+++ b/include/Network/network.hpp
@@ -8,6 +8,8 @@
 #pragma once
 #include <filesystem>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 #ifdef __linux__
 #include "linuxfixes.h"
@@ -57,3 +59,9 @@ void TCPGameServer(const std::string& IP, int Port);
 bool SecurityWarning();
 void CoreSend(std::string data);
 int RecvWaitAll(int sockfd, char *buf, int len);
+void ServerSend(std::string Data, bool Rel);
+extern uint64_t DVSock;
+extern std::unordered_set<std::string> activeVehicles; // set of active serverVehicleIDs for checking if direct vehicle sockets are valid
+extern std::unordered_map<std::string, int> vehiclePortMap; // maps a serverVehicleID to the port of its vehicle socket
+void DVSend(std::string_view Data, int Port);
+void DVClientMain(const std::string& IP, int Port);

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -336,4 +336,29 @@ namespace Utils {
             throw std::runtime_error("Game disconnected");
         }
     }
+
+    // Returns the substring after the first occurence of delim until the next occurence of delim or the end of the string
+    // Returns emtpy string if no delim was found
+    // End index is written back into offset
+    inline std::string getStringBetween(std::string str, char delim, size_t &offset) {
+        size_t first = str.find(delim, offset);
+        if (first == std::string::npos) {
+            return std::string();
+        }
+        first += 1;
+        size_t len = str.find(delim, first);
+        offset = len;
+        if (len != std::string::npos) {
+            len -= first;
+        }
+
+        return str.substr(first, len);
+    }
+
+    // Returns the substring after the first occurence of delim until the next occurence of delim or the end of the string
+    // Returns emtpy string if no delim was found
+    inline std::string getStringBetween(std::string str, char delim) {
+        size_t offset = 0;
+        return getStringBetween(str, delim, offset);
+    }
 };

--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -346,25 +346,39 @@ void Parse(std::string Data, SOCKET CSocket) {
         break;
     }
     case 'V': //register active vehicles for direct vehicle sockets
-        if (Data.length() < 3) {
-            debug("(Core) Failed to parse serverVehicleID from data: " + Data);
-            Data.clear();
-            break;
-        }
-        
         if (SubCode == 'a') {
-            std::string serverVehicleID = Data.substr(3);
-            debug("(Core) Registering vehicle: " + serverVehicleID);
-            activeVehicles.insert(serverVehicleID);
+            size_t offset = 0;
+            std::string serverVehicleID = Utils::getStringBetween(Data, ':', offset);
+            if (serverVehicleID.empty()) {
+                debug("(Core) Failed to parse serverVehicleID from data: " + Data);
+                Data.clear();
+                break;
+            }
+            try {
+                int port = std::stoi(Utils::getStringBetween(Data, ':', offset));
+                debug("(Core) Assigning direct VE connection for vehicle " + serverVehicleID + " to port " + std::to_string(port));
+                vehiclePortMap.insert_or_assign(serverVehicleID, port);
+            } catch (const std::invalid_argument) {
+                debug("(Core) Failed to parse vehicle port from data: " + Data);
+                Data.clear();
+                break;
+            }
         } else if (SubCode == 'd') {
-            std::string serverVehicleID = Data.substr(3);
-            debug("(Core) Unregistering vehicle: " + serverVehicleID);
-            activeVehicles.erase(serverVehicleID);
+            std::string serverVehicleID = Utils::getStringBetween(Data, ':');
+            if (serverVehicleID.empty()) {
+                debug("(Core) Failed to parse serverVehicleID from data: " + Data);
+                Data.clear();
+                break;
+            }
+            debug("(Core) Removed direct VE port for vehicle " + serverVehicleID);
             vehiclePortMap.erase(serverVehicleID);
+        } else if (SubCode == 'r') {
+            debug("(Core) Resetting Direct VE data");
+            vehiclePortMap.clear();
         } else {
             debug("(Core) Invalid V packet SubCode: " + SubCode);
+            Data.clear();
         }
-        Data.clear();
         break;
     default:
         Data.clear();

--- a/src/Network/Core.cpp
+++ b/src/Network/Core.cpp
@@ -345,6 +345,27 @@ void Parse(std::string Data, SOCKET CSocket) {
         });
         break;
     }
+    case 'V': //register active vehicles for direct vehicle sockets
+        if (Data.length() < 3) {
+            debug("(Core) Failed to parse serverVehicleID from data: " + Data);
+            Data.clear();
+            break;
+        }
+        
+        if (SubCode == 'a') {
+            std::string serverVehicleID = Data.substr(3);
+            debug("(Core) Registering vehicle: " + serverVehicleID);
+            activeVehicles.insert(serverVehicleID);
+        } else if (SubCode == 'd') {
+            std::string serverVehicleID = Data.substr(3);
+            debug("(Core) Unregistering vehicle: " + serverVehicleID);
+            activeVehicles.erase(serverVehicleID);
+            vehiclePortMap.erase(serverVehicleID);
+        } else {
+            debug("(Core) Invalid V packet SubCode: " + SubCode);
+        }
+        Data.clear();
+        break;
     default:
         Data.clear();
         break;

--- a/src/Network/DirectVehicleConnection.cpp
+++ b/src/Network/DirectVehicleConnection.cpp
@@ -1,0 +1,125 @@
+/*
+ Copyright (C) 2026 BeamMP Ltd., BeamMP team and contributors.
+ Licensed under AGPL-3.0 (or later), see <https://www.gnu.org/licenses/>.
+ SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+#include "Network/network.hpp"
+#include <stdexcept>
+
+#if defined(_WIN32)
+#include <ws2tcpip.h>
+#elif defined(__linux__)
+#include "linuxfixes.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
+
+#include "Logger.h"
+#include <array>
+#include <string>
+
+SOCKET DVSock = -1;
+sockaddr_in ToVehicle;
+std::unordered_set<std::string> activeVehicles;
+std::unordered_map<std::string, int> vehiclePortMap;
+
+void DVSend(std::string_view Data, int Port) {
+    if (DVSock == -1)
+        return;
+    ToVehicle.sin_port = htons(Port);
+    int sendOk = sendto(DVSock, Data.data(), int(Data.size()), 0, (sockaddr*)&ToVehicle, sizeof(ToVehicle));
+    if (sendOk == SOCKET_ERROR)
+        error("(Direct VE) Failed to send data. Error Code : " + std::to_string(WSAGetLastError()));
+}
+
+void DVRcv() {
+    sockaddr_in FromVehicle;
+    socklen_t size = sizeof(FromVehicle);
+    ZeroMemory(&FromVehicle, size);
+    static thread_local std::array<char, 10240> Ret {};
+    if (DVSock == -1)
+        return;
+    int32_t Rcv = recvfrom(DVSock, Ret.data(), Ret.size() - 1, 0, (sockaddr*)&FromVehicle, &size);
+    if (Rcv == SOCKET_ERROR)
+        return;
+    Ret[Rcv] = 0;
+
+    std::string Data = std::string(Ret.data(), Rcv);
+    size_t first = Data.find(':');
+    if (first == std::string::npos) {
+        debug("(Direct VE) Failed to parse serverVehicleID from data: " + Data);
+        return;
+    }
+    first += 1;
+    size_t len = Data.find(':', first);
+    if (len != std::string::npos) {
+        len -= first;
+    }
+    std::string serverVehicleID = Data.substr(first, len);
+    if (activeVehicles.contains(serverVehicleID)) {
+        int port = ntohs(FromVehicle.sin_port);
+        auto portIter = vehiclePortMap.find(serverVehicleID);
+        if (portIter != vehiclePortMap.end()) {
+            if (portIter->second == port) {
+                ServerSend(Data, false);
+            } else {
+                debug("(Direct VE) Received data for vehicle " + serverVehicleID + " from wrong port: " + std::to_string(port) + " != " + std::to_string(portIter->second));
+            }
+        } else {
+            debug("(Direct VE) Registering port for vehicle " + serverVehicleID + ": " + std::to_string(port));
+            vehiclePortMap.insert({ serverVehicleID, port });
+
+            ServerSend(Data, false);
+        }
+    } else {
+        debug("(Direct VE) Received data from unregistered vehicle: " + serverVehicleID);
+    }
+}
+
+void DVClientMain(const std::string& IP, int Port) {
+    debug("(Direct VE) Starting direct vehicle client on adress " + IP + ":" + std::to_string(Port));
+
+#ifdef _WIN32
+    WSADATA data;
+    if (WSAStartup(514, &data)) {
+        error("(Direct VE) Can't start Winsock!");
+        return;
+    }
+#endif
+    sockaddr_in DVListenAddr;
+    ZeroMemory(&DVListenAddr, sizeof(DVListenAddr));
+    DVListenAddr.sin_family = AF_INET;
+    DVListenAddr.sin_port = htons(Port);
+    inet_pton(AF_INET, IP.c_str(), &DVListenAddr.sin_addr);
+
+    ZeroMemory(&ToVehicle, sizeof(ToVehicle));
+    ToVehicle.sin_family = AF_INET;
+    ToVehicle.sin_addr = DVListenAddr.sin_addr;
+
+    DVSock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (DVSock == INVALID_SOCKET) {
+        error("(Direct VE) Socket creation failed with error: " + std::to_string(WSAGetLastError()));
+        KillSocket(DVSock);
+        WSACleanup();
+        return;
+    }
+    if (bind(DVSock, (const sockaddr*)&DVListenAddr, sizeof(DVListenAddr)) == SOCKET_ERROR) {
+        error("(Direct VE) Socket bind failed with error: " + std::to_string(WSAGetLastError()));
+        KillSocket(DVSock);
+        WSACleanup();
+        return;
+    }
+    debug("(Direct VE) Starting direct vehicle receive loop");
+    while (!TCPTerminate) {
+        DVRcv();
+    }
+    debug("(Direct VE) Direct vehicle receive loop done");
+    KillSocket(DVSock);
+    WSACleanup();
+    activeVehicles.clear();
+    vehiclePortMap.clear();
+}

--- a/src/Network/DirectVehicleConnection.cpp
+++ b/src/Network/DirectVehicleConnection.cpp
@@ -19,12 +19,12 @@
 #endif
 
 #include "Logger.h"
+#include "Utils.h"
 #include <array>
 #include <string>
 
 SOCKET DVSock = -1;
 sockaddr_in ToVehicle;
-std::unordered_set<std::string> activeVehicles;
 std::unordered_map<std::string, int> vehiclePortMap;
 
 void DVSend(std::string_view Data, int Port) {
@@ -49,34 +49,21 @@ void DVRcv() {
     Ret[Rcv] = 0;
 
     std::string Data = std::string(Ret.data(), Rcv);
-    size_t first = Data.find(':');
-    if (first == std::string::npos) {
+    std::string serverVehicleID = Utils::getStringBetween(Data, ':');
+    if (serverVehicleID.empty()) {
         debug("(Direct VE) Failed to parse serverVehicleID from data: " + Data);
         return;
     }
-    first += 1;
-    size_t len = Data.find(':', first);
-    if (len != std::string::npos) {
-        len -= first;
-    }
-    std::string serverVehicleID = Data.substr(first, len);
-    if (activeVehicles.contains(serverVehicleID)) {
-        int port = ntohs(FromVehicle.sin_port);
-        auto portIter = vehiclePortMap.find(serverVehicleID);
-        if (portIter != vehiclePortMap.end()) {
-            if (portIter->second == port) {
-                ServerSend(Data, false);
-            } else {
-                debug("(Direct VE) Received data for vehicle " + serverVehicleID + " from wrong port: " + std::to_string(port) + " != " + std::to_string(portIter->second));
-            }
-        } else {
-            debug("(Direct VE) Registering port for vehicle " + serverVehicleID + ": " + std::to_string(port));
-            vehiclePortMap.insert({ serverVehicleID, port });
-
+    int port = ntohs(FromVehicle.sin_port);
+    auto portIter = vehiclePortMap.find(serverVehicleID);
+    if (portIter != vehiclePortMap.end()) {
+        if (portIter->second == port) {
             ServerSend(Data, false);
+        } else {
+            debug("(Direct VE) Received data for vehicle " + serverVehicleID + " from wrong port: " + std::to_string(port) + " != " + std::to_string(portIter->second));
         }
     } else {
-        debug("(Direct VE) Received data from unregistered vehicle: " + serverVehicleID);
+        debug("(Direct VE) Received data for unregistered vehicle " + serverVehicleID + " from port " + std::to_string(port));
     }
 }
 
@@ -120,6 +107,5 @@ void DVClientMain(const std::string& IP, int Port) {
     debug("(Direct VE) Direct vehicle receive loop done");
     KillSocket(DVSock);
     WSACleanup();
-    activeVehicles.clear();
     vehiclePortMap.clear();
 }

--- a/src/Network/DirectVehicleConnection.cpp
+++ b/src/Network/DirectVehicleConnection.cpp
@@ -101,7 +101,7 @@ void DVClientMain(const std::string& IP, int Port) {
     ToVehicle.sin_addr = DVListenAddr.sin_addr;
 
     DVSock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (DVSock == INVALID_SOCKET) {
+    if (DVSock == -1) {
         error("(Direct VE) Socket creation failed with error: " + std::to_string(WSAGetLastError()));
         KillSocket(DVSock);
         WSACleanup();

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -119,6 +119,11 @@ void NetReset() {
         KillSocket(GSocket);
     }
     GSocket = -1;
+    if (DVSock != (SOCKET)(-1)) {
+        debug("Terminating direct vehicle Socket: " + std::to_string(DVSock));
+        KillSocket(DVSock);
+    }
+    DVSock = -1;
 }
 
 SOCKET SetupListener() {
@@ -182,6 +187,7 @@ int ClientID = -1;
 void ParserAsync(std::string_view Data) {
     if (Data.empty())
         return;
+    bool tryDirectVehicleSocket = false;
     char Code = Data.at(0), SubCode = 0;
     if (Data.length() > 1)
         SubCode = Data.at(1);
@@ -200,10 +206,40 @@ void ParserAsync(std::string_view Data) {
     case 'U':
         magic = Data.substr(1);
         return;
+    case 'R': //controller sync
+    case 'W': //electrics
+    case 'V': //inputs
+    case 'Y': //powertrain
+    case 'X': //nodes
+    case 'Z': //position
+        tryDirectVehicleSocket = true;
+        break;
     default:
         break;
     }
-    GameSend(Data);
+    if (tryDirectVehicleSocket) {
+        size_t first = Data.find(':');
+        if (first == std::string::npos) {
+            GameSend(Data);
+            return;
+        }
+        first += 1;
+        size_t len = Data.find(':', first);
+        if (len != std::string::npos) {
+            len -= first;
+        }
+        std::string serverVehicleID = std::string(Data.substr(first, len));
+        auto portIter = vehiclePortMap.find(serverVehicleID);
+        if (portIter != vehiclePortMap.end()) {
+            DVSend(Data, portIter->second);
+        }
+        else {
+            GameSend(Data);
+        }
+    }
+    else {
+        GameSend(Data);
+    }
 }
 void ServerParser(std::string_view Data) {
     ParserAsync(Data);
@@ -220,6 +256,7 @@ void TCPGameServer(const std::string& IP, int Port) {
     GSocket = SetupListener();
     std::unique_ptr<std::thread> ClientThread {};
     std::unique_ptr<std::thread> NetMainThread {};
+    std::unique_ptr<std::thread> DirectVehicleThread {};
     while (!TCPTerminate && GSocket != -1) {
         debug("MAIN LOOP OF GAME SERVER");
         GConnected = false;
@@ -242,6 +279,7 @@ void TCPGameServer(const std::string& IP, int Port) {
         GConnected = true;
         if (CServer) {
             NetMainThread = std::make_unique<std::thread>(NetMain, IP, Port);
+            DirectVehicleThread = std::make_unique<std::thread>(DVClientMain, "127.0.0.1", options.port + 2);
             CServer = false;
         }
         int32_t Size, Rcv;
@@ -273,6 +311,11 @@ void TCPGameServer(const std::string& IP, int Port) {
         debug("Waiting for net main thread");
         NetMainThread->join();
         debug("Net main thread done");
+    }
+    if (DirectVehicleThread) {
+        debug("Waiting for direct vehicle thread");
+        DirectVehicleThread->join();
+        debug("Direct vehicle thread done");
     }
     if (CSocket != SOCKET_ERROR)
         KillSocket(CSocket);

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -27,7 +27,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include "Options.h"
 #include <chrono>
 
 std::chrono::time_point<std::chrono::high_resolution_clock> PingStart, PingEnd;
@@ -218,17 +217,10 @@ void ParserAsync(std::string_view Data) {
         break;
     }
     if (tryDirectVehicleSocket) {
-        size_t first = Data.find(':');
-        if (first == std::string::npos) {
+        std::string serverVehicleID = Utils::getStringBetween(std::string(Data), ':');
+        if (serverVehicleID.empty()) {
             GameSend(Data);
-            return;
         }
-        first += 1;
-        size_t len = Data.find(':', first);
-        if (len != std::string::npos) {
-            len -= first;
-        }
-        std::string serverVehicleID = std::string(Data.substr(first, len));
         auto portIter = vehiclePortMap.find(serverVehicleID);
         if (portIter != vehiclePortMap.end()) {
             DVSend(Data, portIter->second);


### PR DESCRIPTION
Allows multiple individual VE Lua instances to connect directly to the launcher through a single UDP socket.
This skips having to queue data between VE and GE Lua reducing latency and processing needed on the Lua side.

Requires BeamMP/BeamMP#964 on the Lua side, but is fully compatible with the current Lua mod (falls back to old system).

How it works:
1. The launcher opens a UDP socket for VE Lua instances to connect to.
2. Vehicles need to be registered before any data will be accepted over the direct VE socket. This can be done using `V` packets and the serverVehicleID and port in CoreNetwork. A `Va` packet will register a vehicle, and a `Vd` packet will unregister it. e.g. `Va:0-0:57238` registers a vehicle on port 57238, and `Vd:0-0` unregisters it. `Va` packets can be used to update the port of a vehicle without having to re-register it (e.g. if a VE Lua reload causes a new socket to be created on a different port).
3. Any data sent to the direct VE socket needs to contain a registered serverVehicleID to be valid.
4. Any data that is received from the vehicle socket will be sent to the server as normal, provided the serverVehicleID in the packet matches the one registered for that port. All vehicle specific data received from the server for a connected vehicle will be redirected to its direct socket connection.
5. If a vehicle is not fully connected, the data will be sent over GameNetwork as normal.


This started out as a proof of concept, but initial testing showed very promising results, especially with high amounts of vehicles.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
