### PR TITLE
avoid exposing game to partially written mod files during first download

### DIFF
--- a/src/Network/Resources.cpp
+++ b/src/Network/Resources.cpp
@@ -583,13 +583,17 @@ void NewSyncResources(SOCKET Sock, const std::string& Mods, const std::vector<Mo
                 c = ::tolower(c);
             }
 #endif
+            auto name = std::filesystem::path(GetGamePath()) / "mods/multiplayer" / FName;
+            auto tmp_name = name;
+            tmp_name += ".tmp";
 
             std::error_code ec;
-            fs::copy_file(PathToSaveTo, std::filesystem::path(GetGamePath()) / "mods/multiplayer" / FName, fs::copy_options::overwrite_existing, ec);
+            fs::copy_file(PathToSaveTo, tmp_name, fs::copy_options::overwrite_existing, ec);
             if (ec) {
                 error(beammp_wide("Error in copy_file during download of ") + beammp_fs_string(PathToSaveTo) + beammp_wide(": ") + Utils::ToWString(ec.message()));
                 break;
             }
+            fs::rename(tmp_name, name);
             UpdateModUsage(FName);
         }
         WaitForConfirm();
@@ -748,7 +752,12 @@ void SyncResources(SOCKET Sock) {
             }
 #endif
 
-            fs::copy_file(PathToSaveTo, GetGamePath() / beammp_wide("mods/multiplayer") / Utils::ToWString(FName), fs::copy_options::overwrite_existing);
+            auto name = GetGamePath() / beammp_wide("mods/multiplayer") / Utils::ToWString(FName);
+            auto tmp_name = name;
+            tmp_name += L".tmp";
+
+            fs::copy_file(PathToSaveTo, tmp_name, fs::copy_options::overwrite_existing);
+            fs::rename(tmp_name, name);
             UpdateModUsage(FN->substr(pos));
         }
         WaitForConfirm();


### PR DESCRIPTION
This avoids mod loading failure messages caused by partially copied mod files after initial download, the same way it is already avoided while loading files from cache.

Addresses some instances of https://github.com/BeamMP/BeamMP-Launcher/issues/91

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
