### PR TITLE
Add unreliable (UDP) event support

### DIFF
--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -63,7 +63,7 @@ void GameSend(std::string_view Data) {
 void ServerSend(std::string Data, bool Rel) {
     if (Terminate || Data.empty())
         return;
-    if (Data.compare(0, 2, "Zp") == 0 && Data.size() > 500) {
+    if (Data.starts_with("Zp") && Data.size() > 500) {
         abort();
     }
     char C = 0;

--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -63,7 +63,7 @@ void GameSend(std::string_view Data) {
 void ServerSend(std::string Data, bool Rel) {
     if (Terminate || Data.empty())
         return;
-    if (Data.find("Zp") != std::string::npos && Data.size() > 500) {
+    if (Data.compare(0, 2, "Zp") == 0 && Data.size() > 500) {
         abort();
     }
     char C = 0;
@@ -75,7 +75,7 @@ void ServerSend(std::string Data, bool Rel) {
         Ack = true;
     if (C == 'N' || C == 'W' || C == 'Y' || C == 'V' || C == 'E' || C == 'C')
         Rel = true;
-    if (compressBound(Data.size()) > 1024)
+    if (C != 'e' && compressBound(Data.size()) > 1024)
         Rel = true;
     if (Ack || Rel) {
         if (Ack || DLen > 1000)


### PR DESCRIPTION
Adds an unreliable counterpart to the existing reliable event system, allowing mods to send events over UDP instead of TCP.

### New API

**Server-side Lua:**
- `MP.TriggerClientEventUnreliable(PlayerID, EventName, Data)` — UDP delivery
- `MP.TriggerClientEventJsonUnreliable(PlayerID, EventName, Data)` — JSON variant

**Client-side Lua:**
- `TriggerServerEventUnreliable(EventName, Data)` — sends `e:EventName:Data` to server

### How it works

Reliable events use `E` (uppercase) as the packet prefix, unreliable use `e` (lowercase). Both follow the same code path — the only difference is TCP vs UDP transport.

The launcher skips the >1KB compressed-size TCP upgrade for `e` packets so they stay on UDP regardless of payload size.

### Why

The existing event system only supports reliable delivery. This forces TCP retransmission for every event, which is unnecessary overhead for data that doesn't need guaranteed delivery. This adds the option to opt into UDP where appropriate.

See also: BeamMP/BeamMP-Server#493, BeamMP/BeamMP#892