### PR TITLE
Fix infinite loop in DeComp() on empty input

### DIFF
--- a/src/Compressor.cpp
+++ b/src/Compressor.cpp
@@ -33,6 +33,12 @@ std::vector<char> Comp(std::span<const char> input) {
 }
 
 std::vector<char> DeComp(std::span<const char> input) {
+    // An empty body (e.g. a bare 4-byte "ABG:" frame) sizes output_buffer to 0; zlib then
+    // returns Z_BUF_ERROR forever because the buffer never grows (0 * 2 stays 0 and the size
+    // cap never trips) -> the receive loop spins at 100% CPU for the rest of the session.
+    if (input.empty()) {
+        return {};
+    }
     std::vector<char> output_buffer(std::min<size_t>(input.size() * 5, 15 * 1024 * 1024));
 
     uLongf output_size = output_buffer.size();
@@ -44,11 +50,13 @@ std::vector<char> DeComp(std::span<const char> input) {
             reinterpret_cast<const Bytef*>(input.data()),
             static_cast<uLongf>(input.size()));
         if (res == Z_BUF_ERROR) {
-            if (output_buffer.size() > 30 * 1024 * 1024) {
+            if (output_buffer.size() >= 30 * 1024 * 1024) {
                 throw std::runtime_error("decompressed packet size of 30 MB exceeded");
             }
-            debug("zlib uncompress() failed, trying with 2x buffer size of " + std::to_string(output_buffer.size() * 2));
-            output_buffer.resize(output_buffer.size() * 2);
+            // Grow capped at the 30 MB limit so the >= check above is actually reachable and a
+            // large payload doesn't over-allocate 15 -> 30 -> 60 MB before being rejected.
+            output_buffer.resize(std::min<size_t>(output_buffer.size() * 2, 30u * 1024 * 1024));
+            debug("zlib uncompress() failed, trying with a larger buffer size of " + std::to_string(output_buffer.size()));
             output_size = output_buffer.size();
         } else if (res != Z_OK) {
             error("zlib uncompress() failed (code: " + std::to_string(res) + ", message: " + zError(res) + ")");


### PR DESCRIPTION
### Problem

`DeComp()` in `src/Compressor.cpp` loops forever on **empty input**: a zero-length compressed body (e.g. a bare 4-byte `ABG:` frame, which a buggy or malicious peer can send) sizes `output_buffer` to 0, zlib returns `Z_BUF_ERROR`, and the grow step `output_buffer.size() * 2` stays 0 forever — the 30 MB cap is never reached, so the receive loop spins at 100% CPU for the rest of the session.

Two adjacent issues in the same loop:
- the cap check uses `>` while the buffer can only ever *equal* the value it's compared against after capping — changed to `>=`;
- growth was uncapped, so a large legitimate payload over-allocated 15 → 30 → 60 MB before being rejected.

### Fix

Reject empty input up front (return an empty buffer — the caller already treats a failed decompress as a dropped packet), cap the growth at the 30 MB limit, and check the cap with `>=`. The server's `DeComp` (in BeamMP-Server `Common.cpp`) already terminates on this input after its buffer-management rework; this brings the launcher to parity.

### How this was found

Found during a robustness audit of a LAN fork of BeamMP (the same bug existed in the fork's server base and was reachable from any peer); the fix has been running in that fork for weeks of sessions.

### Transparency

This fix comes from an AI-assisted fork: the bug was found and the patch written with the help of an AI coding tool (Claude), then tested by a human in real multiplayer sessions. Given this project's policy on AI-generated code, it's submitted as a **draft** for the maintainers to decide — happy to close it if that's not wanted, or for a maintainer to re-implement it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
