### PR TITLE
Do not abort() on an oversized position packet

### DIFF
--- a/src/Network/GlobalHandler.cpp
+++ b/src/Network/GlobalHandler.cpp
@@ -63,8 +63,13 @@ void GameSend(std::string_view Data) {
 void ServerSend(std::string Data, bool Rel) {
     if (Terminate || Data.empty())
         return;
-    if (Data.find("Zp") != std::string::npos && Data.size() > 500) {
-        abort();
+    if (Data.size() > 500 && Data[0] == 'Z' && Data[1] == 'p') {
+        // Was abort() -- a process-killing crash reachable by ordinary runtime data (an
+        // oversized position packet). It also matched "Zp" ANYWHERE in the payload, so an
+        // unrelated packet that merely contained those two bytes could kill the launcher.
+        // Check the actual packet code and drop the oversized packet instead.
+        debug("Dropping oversized 'Zp' packet (" + std::to_string(Data.size()) + " bytes)");
+        return;
     }
     char C = 0;
     bool Ack = false;


### PR DESCRIPTION
### Problem

`ServerSend()` in `src/Network/GlobalHandler.cpp` calls **`abort()`** — a process-killing crash — when a packet over 500 bytes contains `"Zp"`. Two problems:

1. Ordinary runtime data can trigger it: an oversized position packet should be dropped, not take down the whole launcher (and with it the player's session).
2. `Data.find("Zp") != npos` matches those two bytes **anywhere** in the payload — so an unrelated packet (chat message, event payload, mod data) that merely contains the substring `Zp` and is over 500 bytes kills the launcher too.

### Fix

Check the actual packet code (`Data[0] == 'Z' && Data[1] == 'p'` — safe, the size check precedes it) and drop the oversized packet with a debug log instead of aborting.

### How this was found

Hit in practice on a LAN fork of BeamMP (an oversized position payload aborted the launcher mid-session); the graceful-drop version has been running in that fork for weeks of sessions.

### Transparency

This fix comes from an AI-assisted fork: the bug was found and the patch written with the help of an AI coding tool (Claude), then tested by a human in real multiplayer sessions. Given this project's policy on AI-generated code, it's submitted as a **draft** for the maintainers to decide — happy to close it if that's not wanted, or for a maintainer to re-implement it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
