### PR TITLE
Fix: BeamNG.drive not detected due to case-sensitive path mismatch in libraryfolders.vdf

### DIFF
--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -163,48 +163,60 @@ void FileList(std::vector<std::string>& a, const std::string& Path) {
     }
 }
 #if defined(__linux__)
-bool TryResolveGameDir(const std::string& libraryPath, std::string& outGameDir) {
-    namespace fs = std::filesystem;
-
-    std::vector<fs::path> components;
-    for (const auto& part : fs::path(libraryPath)) {
-        components.push_back(part);
-    }
-
-    auto buildAndCheck = [&](const std::vector<fs::path>& parts) -> bool {
-        fs::path candidate;
-        for (const auto& part : parts) {
-            candidate /= part;
-        }
-        std::string gameDir = candidate.string() + "/steamapps/common/BeamNG.drive/";
-        if (fs::exists(gameDir + "integrity.json")) {
-            outGameDir = gameDir;
-            return true;
-        }
-        return false;
-    };
-
-    if (buildAndCheck(components)) {
+static bool ResolvePathComponent(const fs::path& parentDir, const std::string& want, fs::path& resolved) {
+    std::error_code ec;
+    fs::path exact = parentDir / want;
+    if (fs::exists(exact, ec)) {
+        resolved = exact;
         return true;
     }
 
-    for (size_t i = 0; i < components.size(); ++i) {
-        std::string original = components[i].string();
-        std::string upper = original;
-        std::string lower = original;
-        std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) { return std::toupper(c); });
-        std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (!fs::is_directory(parentDir, ec)) {
+        return false;
+    }
 
-        for (const auto& variant : { upper, lower }) {
-            if (variant == original) {
-                continue;
-            }
-            auto modified = components;
-            modified[i] = variant;
-            if (buildAndCheck(modified)) {
-                return true;
-            }
+    std::string wantLower = want;
+    std::transform(wantLower.begin(), wantLower.end(), wantLower.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    for (const auto& entry : fs::directory_iterator(parentDir, ec)) {
+        std::string nameLower = entry.path().filename().string();
+        std::transform(nameLower.begin(), nameLower.end(), nameLower.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (nameLower == wantLower) {
+            resolved = entry.path();
+            return true;
         }
+    }
+    return false;
+}
+
+bool TryResolveGameDir(const std::string& libraryPath, std::string& outGameDir) {
+    fs::path current;
+    bool first = true;
+    for (const auto& part : fs::path(libraryPath)) {
+        if (first) {
+            current = part;
+            first = false;
+            continue;
+        }
+        fs::path resolved;
+        if (!ResolvePathComponent(current, part.string(), resolved)) {
+            return false;
+        }
+        current = resolved;
+    }
+
+    for (const std::string& want : { std::string("steamapps"), std::string("common"), std::string("BeamNG.drive") }) {
+        fs::path resolved;
+        if (!ResolvePathComponent(current, want, resolved)) {
+            return false;
+        }
+        current = resolved;
+    }
+
+    std::error_code ec;
+    if (fs::exists(current / "integrity.json", ec)) {
+        outGameDir = current.string() + "/";
+        return true;
     }
     return false;
 }
@@ -321,7 +333,11 @@ void LegitimacyCheck() {
         if (!folderInfo.second) {
             continue;
         }
-        const std::string& libraryPath = folderInfo.second->attribs["path"];
+        auto pathAttrib = folderInfo.second->attribs.find("path");
+        if (pathAttrib == folderInfo.second->attribs.end()) {
+            continue;
+        }
+        const std::string& libraryPath = pathAttrib->second;
 
         auto appsChild = folderInfo.second->childs.find("apps");
         if (appsChild == folderInfo.second->childs.end() || !appsChild->second) {
@@ -333,6 +349,7 @@ void LegitimacyCheck() {
             continue;
         }
 
+        debug("Checking Steam library for BeamNG.drive: " + libraryPath);
         std::string resolvedGameDir;
         if (TryResolveGameDir(libraryPath, resolvedGameDir)) {
             GameDir = resolvedGameDir;

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -284,7 +284,6 @@ void LegitimacyCheck() {
     std::vector<std::filesystem::path> steamappsCommonPaths = {
         ".steam/root/steamapps", // default
         ".steam/steam/steamapps", // Legacy Steam installations
-        ".local/share/Steam/steamapps", // Arch Linux, Fedora, and other distros~
         ".var/app/com.valvesoftware.Steam/.steam/root/steamapps", // flatpak
         "snap/steam/common/.local/share/Steam/steamapps" // snap
     };
@@ -299,7 +298,6 @@ void LegitimacyCheck() {
         if (std::filesystem::exists(steamappsPath)) {
             steamappsFolderFound = true;
             libraryFoldersPath = steamappsPath / "libraryfolders.vdf";
-            info("Found Steam installation at: " + steamappsPath.string());
             if (std::filesystem::exists(libraryFoldersPath)) {
                 libraryFoldersPath = libraryFoldersPath;
                 libraryFoldersFound = true;
@@ -324,7 +322,6 @@ void LegitimacyCheck() {
             continue;
         }
         const std::string& libraryPath = folderInfo.second->attribs["path"];
-        info("Checking folder: " + libraryPath);
 
         auto appsChild = folderInfo.second->childs.find("apps");
         if (appsChild == folderInfo.second->childs.end() || !appsChild->second) {

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -189,7 +189,11 @@ static bool ResolvePathComponent(const fs::path& parentDir, const std::string& w
     return false;
 }
 
-bool TryResolveGameDir(const std::string& libraryPath, std::string& outGameDir) {
+static bool TryResolveGameDir(const std::string& libraryPath, std::string& outGameDir) {
+    if (libraryPath.empty()) {
+        return false;
+    }
+
     fs::path current;
     bool first = true;
     for (const auto& part : fs::path(libraryPath)) {

--- a/src/Security/BeamNG.cpp
+++ b/src/Security/BeamNG.cpp
@@ -11,6 +11,8 @@
 #include <shlobj_core.h>
 #elif defined(__linux__)
 #include "vdf_parser.hpp"
+#include <algorithm>
+#include <cctype>
 #include <pwd.h>
 #include <unistd.h>
 #include <vector>
@@ -160,6 +162,54 @@ void FileList(std::vector<std::string>& a, const std::string& Path) {
         }
     }
 }
+#if defined(__linux__)
+bool TryResolveGameDir(const std::string& libraryPath, std::string& outGameDir) {
+    namespace fs = std::filesystem;
+
+    std::vector<fs::path> components;
+    for (const auto& part : fs::path(libraryPath)) {
+        components.push_back(part);
+    }
+
+    auto buildAndCheck = [&](const std::vector<fs::path>& parts) -> bool {
+        fs::path candidate;
+        for (const auto& part : parts) {
+            candidate /= part;
+        }
+        std::string gameDir = candidate.string() + "/steamapps/common/BeamNG.drive/";
+        if (fs::exists(gameDir + "integrity.json")) {
+            outGameDir = gameDir;
+            return true;
+        }
+        return false;
+    };
+
+    if (buildAndCheck(components)) {
+        return true;
+    }
+
+    for (size_t i = 0; i < components.size(); ++i) {
+        std::string original = components[i].string();
+        std::string upper = original;
+        std::string lower = original;
+        std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) { return std::toupper(c); });
+        std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+
+        for (const auto& variant : { upper, lower }) {
+            if (variant == original) {
+                continue;
+            }
+            auto modified = components;
+            modified[i] = variant;
+            if (buildAndCheck(modified)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+#endif
+
 void LegitimacyCheck() {
 #if defined(_WIN32)
     wchar_t* appDataPath = new wchar_t[MAX_PATH];
@@ -234,6 +284,7 @@ void LegitimacyCheck() {
     std::vector<std::filesystem::path> steamappsCommonPaths = {
         ".steam/root/steamapps", // default
         ".steam/steam/steamapps", // Legacy Steam installations
+        ".local/share/Steam/steamapps", // Arch Linux, Fedora, and other distros~
         ".var/app/com.valvesoftware.Steam/.steam/root/steamapps", // flatpak
         "snap/steam/common/.local/share/Steam/steamapps" // snap
     };
@@ -248,6 +299,7 @@ void LegitimacyCheck() {
         if (std::filesystem::exists(steamappsPath)) {
             steamappsFolderFound = true;
             libraryFoldersPath = steamappsPath / "libraryfolders.vdf";
+            info("Found Steam installation at: " + steamappsPath.string());
             if (std::filesystem::exists(libraryFoldersPath)) {
                 libraryFoldersPath = libraryFoldersPath;
                 libraryFoldersFound = true;
@@ -267,9 +319,26 @@ void LegitimacyCheck() {
 
     std::ifstream libraryFolders(libraryFoldersPath);
     auto root = tyti::vdf::read(libraryFolders);
-    for (auto folderInfo : root.childs) {
-        if ((folderInfo.second->childs["apps"]->attribs).contains("284160") && std::filesystem::exists(folderInfo.second->attribs["path"] + "/steamapps/common/BeamNG.drive/integrity.json")){
-            GameDir = folderInfo.second->attribs["path"] + "/steamapps/common/BeamNG.drive/";
+    for (const auto& folderInfo : root.childs) {
+        if (!folderInfo.second) {
+            continue;
+        }
+        const std::string& libraryPath = folderInfo.second->attribs["path"];
+        info("Checking folder: " + libraryPath);
+
+        auto appsChild = folderInfo.second->childs.find("apps");
+        if (appsChild == folderInfo.second->childs.end() || !appsChild->second) {
+            continue;
+        }
+
+        const auto& apps = appsChild->second->attribs;
+        if (apps.find("284160") == apps.end()) {
+            continue;
+        }
+
+        std::string resolvedGameDir;
+        if (TryResolveGameDir(libraryPath, resolvedGameDir)) {
+            GameDir = resolvedGameDir;
             break;
         }
     }


### PR DESCRIPTION
Steam's libraryfolders.vdf can record a library path with different casing than what's actually on disk (e.g. /mnt/hdd vs /mnt/HDD). On case-sensitive filesystems this made std::filesystem::exists() fail silently, so BeamNG.drive was never detected even when installed.
Changes:

Added TryResolveGameDir(): resolves a game's install path segment-by-segment, falling back to a case-insensitive directory scan when the exact-case path doesn't exist. Confirms success by checking for integrity.json in the resolved folder.
Added debug logging showing which Steam install/library path is being checked, to make future detection issues easier to diagnose.

Testing: verified against a library where the VDF path casing didn't match the actual mount point casing; BeamNG.drive is now detected correctly.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
