### PR TITLE
Fix TCP connection drops caused by thread interleaving in TCPSend

### DIFF
--- a/src/Network/VehicleEvent.cpp
+++ b/src/Network/VehicleEvent.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <iostream>
 #include <vector>
+#include <mutex>
 
 #if defined(_WIN32)
 #include <ws2tcpip.h>
@@ -50,7 +51,11 @@ void UUl(const std::string& R) {
     UlStatus = "UlDisconnected: " + R;
 }
 
+std::mutex TCPSendMutex;
+
 void TCPSend(const std::string& Data, uint64_t Sock) {
+    std::scoped_lock lock(TCPSendMutex);
+
     if (Sock == -1) {
         Terminate = true;
         UUl("Invalid Socket");


### PR DESCRIPTION
This commit addresses the mysterious connection drops that occur under heavy load.

Added `TCPSendMutex` to `TCPSend` in `VehicleEvent.cpp`. While `UDPSend`, `GameSend`, and `CoreSend` all had dedicated mutexes, `TCPSend` was missing one. This allowed the background `AutoPing` thread to occasionally collide with the main event loop while sending data. This interleaving corrupted the TCP headers, causing the server to instantly terminate the connection due to malformed packets. `TCPSend` is now safely locked with a `std::scoped_lock`.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
