### PR TITLE
Handle incomplete MSG_WAITALL when receiving from the game

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -314,14 +314,26 @@ namespace Utils {
         return buffer;
     }
 
+    /// Throws!!!
+    inline void RecvExactly(SOCKET socket, char* buffer, size_t size) {
+        size_t received = 0;
+        while (received < size) {
+            auto n = recv(socket, buffer + received, static_cast<int>(size - received), MSG_WAITALL);
+            if (n < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                throw std::runtime_error(std::string("recv() failed: ") + std::strerror(errno));
+            } else if (n == 0) {
+                throw std::runtime_error("Game disconnected");
+            }
+            received += static_cast<size_t>(n);
+        }
+    }
+
     inline uint32_t RecvHeader(SOCKET socket) {
         std::array<uint8_t, sizeof(uint32_t)> header_buffer {};
-        auto n = recv(socket, reinterpret_cast<char*>(header_buffer.data()), header_buffer.size(), MSG_WAITALL);
-        if (n < 0) {
-            throw std::runtime_error(std::string("recv() of header failed: ") + std::strerror(errno));
-        } else if (n == 0) {
-            throw std::runtime_error("Game disconnected");
-        }
+        RecvExactly(socket, reinterpret_cast<char*>(header_buffer.data()), header_buffer.size());
         return *reinterpret_cast<uint32_t*>(header_buffer.data());
     }
 
@@ -329,11 +341,6 @@ namespace Utils {
     inline void ReceiveFromGame(SOCKET socket, std::vector<char>& out_data) {
         auto header = RecvHeader(socket);
         out_data.resize(header);
-        auto n = recv(socket, reinterpret_cast<char*>(out_data.data()), out_data.size(), MSG_WAITALL);
-        if (n < 0) {
-            throw std::runtime_error(std::string("recv() of data failed: ") + std::strerror(errno));
-        } else if (n == 0) {
-            throw std::runtime_error("Game disconnected");
-        }
+        RecvExactly(socket, out_data.data(), out_data.size());
     }
 };


### PR DESCRIPTION
### The problem

When the game sends the launcher a packet larger than about 8 KB, the launcher can pass a damaged copy of it to the server and then lose track of where the next packet begins.

Every packet from the game arrives as a 4-byte length followed by that many bytes. `ReceiveFromGame()` asks for the whole packet in one `recv()` with `MSG_WAITALL`, but never checks how many bytes actually came back. `MSG_WAITALL` is allowed to return early — exactly the case `RecvWaitAll()` in `src/Network/VehicleEvent.cpp` was written for ("happens frequently in wine, and can also happen natively when the OS pauses the execution"). That helper is used for the socket facing the server; the socket facing the game still uses a plain `recv()`.

When the read does return early, two things go wrong at once:

1. The buffer was resized before the read, so the part that never arrived stays as zero bytes, and the launcher sends the server a full-length packet with a tail of NULs. The server cannot parse it.
2. The bytes that were not read are still sitting in the socket. The next read takes 4 bytes out of the middle of the old packet and treats them as the length of a new one. From that point on, the launcher sends the server packets the game never produced.

### What this looks like in practice

Any vehicle whose spawn data is bigger than 8188 bytes — large modded cars, trailers with many parts — breaks the session. On our server (launcher 2.8.1, server 3.9.3, BeamNG 0.39.4, Wine on macOS) attaching a trailer kicked the player every time. The server logs `Failed to parse vehicle data as json`, and the connection is terminated shortly after.

Two lines from the launcher log that show what is happening. First, a packet that leaves the launcher compressed far better than a healthy packet of the same size, because most of its tail is zeros:

```
[DEBUG] zlib compressed 10509 B to 1125 B
[DEBUG] (Launcher->Server) Bytes sent: 10509 : Os:0:{"pro
```

Second, a packet the game never sent — it is a slice out of the middle of the previous vehicle config, produced after the framing was lost:

```
[DEBUG] (Launcher->Server) Bytes sent: 1285 : Yl:0-1:{"d"dually"}}
```

Where the 8188 comes from: the game writes the length and the data with a single `socket:send()`, and LuaSocket splits that into 8192-byte writes. So the launcher can wake up after the first chunk (4 bytes of length + 8188 bytes of data) while the rest is still on the way. In two separate incidents the data that reached the server was cut at exactly that boundary.

This is the same kind of failure as #185, on the other socket.

### The change

`RecvExactly()` keeps reading until the buffer is full, the way `RecvWaitAll()` already does for the server-facing socket. `RecvHeader()` and `ReceiveFromGame()` now use it. The error messages and the exceptions thrown are unchanged.

`EINTR` is retried instead of being treated as a failure. Without that, a read interrupted before any data has arrived turns into a `recv() failed` disconnect — the corruption would simply be traded for a dropped connection.

### Testing

A small standalone program was used to compare the old and the new behaviour: it sends the same 10507-byte packet through a socket pair in 8192-byte chunks and interrupts the read once, then checks what each version assembled.

```
Payload: 10507 bytes (frame 10511)

[before]   frame=10511B -> received 10507B, NUL-tail=2319B, intact=NO
[after]    frame=10511B -> received 10507B, NUL-tail=0B,    intact=yes
```

The NUL tail on the first line is the same symptom seen on the live server. Happy to attach that test program if it is useful.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
